### PR TITLE
Add evaluator events proto.

### DIFF
--- a/xls/codegen/block_stitching_pass_test.cc
+++ b/xls/codegen/block_stitching_pass_test.cc
@@ -27,8 +27,6 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/algorithm/container.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
@@ -42,6 +40,8 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/substitute.h"
 #include "absl/types/span.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/block_conversion.h"
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_pass.h"
@@ -714,10 +714,10 @@ struct BlockEvaluationOutputsEqMatcher {
 
   bool MatchAndExplain(const BlockEvaluationResults& results,
                        ::testing::MatchResultListener* listener) const {
-    if (!results.interpreter_events.assert_msgs.empty()) {
+    if (!results.interpreter_events.GetAssertMessages().empty()) {
       *listener << absl::StreamFormat(
           "Unexpected assertion failures: %s.",
-          absl::StrJoin(results.interpreter_events.assert_msgs, ", "));
+          absl::StrJoin(results.interpreter_events.GetAssertMessages(), ", "));
       return false;
     }
     if (results.actual_outputs != expected_outputs) {
@@ -4998,8 +4998,8 @@ TEST_F(BlockStitchingPassTest, ProcWithAssert) {
       EvalBlock(top_block, context.metadata(), {{"in", {100, 200, 300, 0}}}),
       IsOkAndHolds(Field(
           "interpreter_events", &BlockEvaluationResults::interpreter_events,
-          Field("assert_msgs", &InterpreterEvents::assert_msgs,
-                ElementsAre(HasSubstr("input must not be zero"))))));
+          Property(&InterpreterEvents::GetAssertMessages,
+                   ElementsAre(HasSubstr("input must not be zero"))))));
 }
 
 TEST_F(BlockStitchingPassTest, ProcWithCover) {
@@ -5140,12 +5140,10 @@ TEST_F(BlockStitchingPassTest, ProcWithTrace) {
 
   EXPECT_THAT(
       interpreter->GetInterpreterEvents(p->GetProc("trace_not_zero").value())
-          .trace_msgs,
-      ElementsAre(FieldsAre(HasSubstr("data: 100"), 0),
-                  FieldsAre(HasSubstr("data: 200"), 0),
-                  FieldsAre(HasSubstr("data: 300"), 0),
-                  FieldsAre(HasSubstr("data: 400"), 0),
-                  FieldsAre(HasSubstr("data: 500"), 0)));
+          .GetTraceMessageStrings(),
+      ElementsAre(HasSubstr("data: 100"), HasSubstr("data: 200"),
+                  HasSubstr("data: 300"), HasSubstr("data: 400"),
+                  HasSubstr("data: 500")));
 
   XLS_ASSERT_OK_AND_ASSIGN(
       (auto [changed, context]),
@@ -5163,12 +5161,11 @@ TEST_F(BlockStitchingPassTest, ProcWithTrace) {
           BlockOutputsEq({{"out", {100, 200, 300, 0, 400, 0, 500}}}),
           Field("interpreter_events",
                 &BlockEvaluationResults::interpreter_events,
-                Field("trace_msgs", &InterpreterEvents::trace_msgs,
-                      ElementsAre(FieldsAre(HasSubstr("data: 100"), 0),
-                                  FieldsAre(HasSubstr("data: 200"), 0),
-                                  FieldsAre(HasSubstr("data: 300"), 0),
-                                  FieldsAre(HasSubstr("data: 400"), 0),
-                                  FieldsAre(HasSubstr("data: 500"), 0)))))));
+                Property(
+                    &InterpreterEvents::GetTraceMessageStrings,
+                    ElementsAre(HasSubstr("data: 100"), HasSubstr("data: 200"),
+                                HasSubstr("data: 300"), HasSubstr("data: 400"),
+                                HasSubstr("data: 500")))))));
 }
 
 TEST_F(BlockStitchingPassTest, ProcWithNonblockingReceivesWithPassthrough) {

--- a/xls/codegen/maybe_materialize_fifos_pass_test.cc
+++ b/xls/codegen/maybe_materialize_fifos_pass_test.cc
@@ -21,17 +21,17 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "xls/common/fuzzing/fuzztest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "absl/types/span.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/codegen_pass.h"
 #include "xls/codegen/fifo_model_test_utils.h"
+#include "xls/common/fuzzing/fuzztest.h"
 #include "xls/common/status/matchers.h"
 #include "xls/common/status/ret_check.h"
 #include "xls/common/status/status_macros.h"
@@ -164,7 +164,8 @@ class MaterializeFifosPassTestHelper {
       ScopedMaybeRecord input_inst("input", input_set_inst);
       ScopedMaybeRecord test_out("test_output", tester_outputs);
       ScopedMaybeRecord oracle_out("oracle_output", oracle->output_ports());
-      ScopedMaybeRecord trace("trace", tester->events().trace_msgs);
+      ScopedMaybeRecord trace("trace",
+                              tester->events().GetTraceMessageStrings());
       ASSERT_THAT(tester_outputs,
                   UsableOutputsMatch(input_set_inst, oracle->output_ports()))
           << "@" << i << ". tester_state: {"

--- a/xls/codegen/side_effect_condition_pass_test.cc
+++ b/xls/codegen/side_effect_condition_pass_test.cc
@@ -21,14 +21,14 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_split.h"
 #include "absl/types/span.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/block_conversion.h"
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_pass.h"
@@ -159,9 +159,9 @@ class SideEffectConditionPassTest
     for (const absl::flat_hash_map<std::string, Value>& input_set : inputs) {
       XLS_RETURN_IF_ERROR(continuation->RunOneCycle(input_set));
       XLS_RETURN_IF_ERROR(InterpreterEventsToStatus(continuation->events()));
-      for (const TraceMessage& trace : continuation->events().trace_msgs) {
-        traces.push_back(trace.message);
-      }
+      const std::vector<std::string> msgs =
+          continuation->events().GetTraceMessageStrings();
+      traces.insert(traces.end(), msgs.begin(), msgs.end());
     }
     return traces;
   }

--- a/xls/contrib/xlscc/unit_tests/translator_proc_test.cc
+++ b/xls/contrib/xlscc/unit_tests/translator_proc_test.cc
@@ -19,17 +19,17 @@
 #include <string>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_format.h"
+#include "gmock/gmock.h"
 #include "google/protobuf/message.h"
 #include "google/protobuf/text_format.h"
 #include "google/protobuf/util/message_differencer.h"
+#include "gtest/gtest.h"
 #include "xls/common/casts.h"
 #include "xls/common/status/matchers.h"
 #include "xls/contrib/xlscc/hls_block.pb.h"
@@ -4815,7 +4815,8 @@ TEST_P(TranslatorProcTest, IOProcClass) {
   )";
 
   xlscc::HLSBlock ref_meta;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(ref_meta_str, &ref_meta));
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(ref_meta_str, &ref_meta));
 
   std::string diff;
   google::protobuf::util::MessageDifferencer differencer;
@@ -5254,7 +5255,8 @@ TEST_P(TranslatorProcTest_OldFSMOnly, IOProcClassSubClass) {
   )";
 
   xlscc::HLSBlock ref_meta;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(ref_meta_str, &ref_meta));
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(ref_meta_str, &ref_meta));
 
   std::string diff;
   google::protobuf::util::MessageDifferencer differencer;
@@ -5699,7 +5701,8 @@ TEST_P(TranslatorProcTest, IOProcClassEnumMember) {
   )";
 
   xlscc::HLSBlock ref_meta;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(ref_meta_str, &ref_meta));
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(ref_meta_str, &ref_meta));
 
   std::string diff;
   google::protobuf::util::MessageDifferencer differencer;
@@ -5759,7 +5762,8 @@ TEST_P(TranslatorProcTest, IOProcClassMemberSetConstruct) {
   )";
 
   xlscc::HLSBlock ref_meta;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(ref_meta_str, &ref_meta));
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(ref_meta_str, &ref_meta));
 
   std::string diff;
   google::protobuf::util::MessageDifferencer differencer;
@@ -5866,7 +5870,8 @@ TEST_P(TranslatorProcTest, IOProcClassLValueInit) {
   )";
 
   xlscc::HLSBlock ref_meta;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(ref_meta_str, &ref_meta));
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(ref_meta_str, &ref_meta));
 
   std::string diff;
   google::protobuf::util::MessageDifferencer differencer;
@@ -5931,7 +5936,8 @@ TEST_P(TranslatorProcTest_OldFSMOnly, IOProcClassHierarchicalLValue) {
   )";
 
   xlscc::HLSBlock ref_meta;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(ref_meta_str, &ref_meta));
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(ref_meta_str, &ref_meta));
 
   std::string diff;
   google::protobuf::util::MessageDifferencer differencer;
@@ -6424,8 +6430,7 @@ TEST_P(TranslatorProcTest, DebugTrace) {
   }
   {
     xls::InterpreterEvents expected_events;
-    expected_events.trace_msgs.push_back(
-        xls::TraceMessage{.message = "Value is 9", .verbosity = 0});
+    expected_events.AddTraceStatementMessage(/*verbosity=*/0, "Value is 9");
 
     absl::flat_hash_map<std::string, std::list<xls::Value>> inputs;
     inputs["in"] = {xls::Value(xls::SBits(9, 32))};
@@ -6465,14 +6470,10 @@ TEST_P(TranslatorProcTest, DebugTraceInPipelinedLoop) {
 
   {
     xls::InterpreterEvents expected_events;
-    expected_events.trace_msgs.push_back(
-        xls::TraceMessage{.message = "Value is 0", .verbosity = 0});
-    expected_events.trace_msgs.push_back(
-        xls::TraceMessage{.message = "Value is 1", .verbosity = 0});
-    expected_events.trace_msgs.push_back(
-        xls::TraceMessage{.message = "Value is 2", .verbosity = 0});
-    expected_events.trace_msgs.push_back(
-        xls::TraceMessage{.message = "Value is 4", .verbosity = 0});
+    expected_events.AddTraceStatementMessage(/*verbosity=*/0, "Value is 0");
+    expected_events.AddTraceStatementMessage(/*verbosity=*/0, "Value is 1");
+    expected_events.AddTraceStatementMessage(/*verbosity=*/0, "Value is 2");
+    expected_events.AddTraceStatementMessage(/*verbosity=*/0, "Value is 4");
 
     absl::flat_hash_map<std::string, std::list<xls::Value>> inputs;
     inputs["in"] = {xls::Value(xls::SBits(4, 32))};

--- a/xls/dslx/tests/trace_fmt_array/trace_fmt_array_test.cc
+++ b/xls/dslx/tests/trace_fmt_array/trace_fmt_array_test.cc
@@ -25,10 +25,6 @@ namespace xls {
 namespace {
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
-
-MATCHER_P(TraceMessage, m, "") {
-  return testing::ExplainMatchResult(m, arg.message, result_listener);
-}
 TEST(TraceFmtArray, TraceHasCommas) {
   XLS_ASSERT_OK_AND_ASSIGN(auto trace, wrapped::TraceIt::Create());
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -38,10 +34,9 @@ TEST(TraceFmtArray, TraceHasCommas) {
                            trace->jit()->Run({input}));
 
   EXPECT_EQ(res.value.bits(), UBits(1, 8));
-  EXPECT_THAT(res.events.assert_msgs, IsEmpty());
-  EXPECT_THAT(
-      res.events.trace_msgs,
-      ElementsAre(TraceMessage("The array is [1, 2, 3, 4, 5, 6, 7, 8]")));
+  EXPECT_THAT(res.events.GetAssertMessages(), IsEmpty());
+  EXPECT_THAT(res.events.GetTraceMessageStrings(),
+              ElementsAre("The array is [1, 2, 3, 4, 5, 6, 7, 8]"));
 }
 
 }  // namespace

--- a/xls/dslx/tests/trace_fmt_issue_651/trace_fmt_test.cc
+++ b/xls/dslx/tests/trace_fmt_issue_651/trace_fmt_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "absl/types/span.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "absl/types/span.h"
 #include "xls/common/status/matchers.h"
 #include "xls/dslx/tests/trace_fmt_issue_651/trace_enum_wrapper.h"
 #include "xls/dslx/tests/trace_fmt_issue_651/trace_s32_wrapper.h"
@@ -31,10 +31,6 @@ namespace xls {
 namespace {
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
-
-MATCHER_P(TraceMessage, m, "") {
-  return testing::ExplainMatchResult(m, arg.message, result_listener);
-}
 TEST(TraceFmt, LeadingOneU16) {
   XLS_ASSERT_OK_AND_ASSIGN(auto trace, wrapped::Trace_u16::Create());
   XLS_ASSERT_OK_AND_ASSIGN(auto input,
@@ -42,9 +38,9 @@ TEST(TraceFmt, LeadingOneU16) {
   XLS_ASSERT_OK_AND_ASSIGN(InterpreterResult<Value> res,
                            trace->jit()->Run({input}));
 
-  EXPECT_THAT(res.events.assert_msgs, IsEmpty());
-  EXPECT_THAT(res.events.trace_msgs,
-              ElementsAre(TraceMessage("1111_1111_0000_0000")));
+  EXPECT_THAT(res.events.GetAssertMessages(), IsEmpty());
+  EXPECT_THAT(res.events.GetTraceMessageStrings(),
+              ElementsAre("1111_1111_0000_0000"));
 }
 
 TEST(TraceFmt, ZeroPaddedU16) {
@@ -54,9 +50,9 @@ TEST(TraceFmt, ZeroPaddedU16) {
   XLS_ASSERT_OK_AND_ASSIGN(InterpreterResult<Value> res,
                            trace->jit()->Run({input}));
 
-  EXPECT_THAT(res.events.assert_msgs, IsEmpty());
-  EXPECT_THAT(res.events.trace_msgs,
-              ElementsAre(TraceMessage("0000_0000_0111_0000")));
+  EXPECT_THAT(res.events.GetAssertMessages(), IsEmpty());
+  EXPECT_THAT(res.events.GetTraceMessageStrings(),
+              ElementsAre("0000_0000_0111_0000"));
 }
 
 TEST(TraceFmt, LeadingOneU21) {
@@ -67,9 +63,9 @@ TEST(TraceFmt, LeadingOneU21) {
   XLS_ASSERT_OK_AND_ASSIGN(InterpreterResult<Value> res,
                            trace->jit()->Run({input}));
 
-  EXPECT_THAT(res.events.assert_msgs, IsEmpty());
-  EXPECT_THAT(res.events.trace_msgs,
-              ElementsAre(TraceMessage("1_0001_0001_0001_0001_0001")));
+  EXPECT_THAT(res.events.GetAssertMessages(), IsEmpty());
+  EXPECT_THAT(res.events.GetTraceMessageStrings(),
+              ElementsAre("1_0001_0001_0001_0001_0001"));
 }
 
 TEST(TraceFmt, ZeroPaddedU21) {
@@ -79,9 +75,9 @@ TEST(TraceFmt, ZeroPaddedU21) {
   XLS_ASSERT_OK_AND_ASSIGN(InterpreterResult<Value> res,
                            trace->jit()->Run({input}));
 
-  EXPECT_THAT(res.events.assert_msgs, IsEmpty());
-  EXPECT_THAT(res.events.trace_msgs,
-              ElementsAre(TraceMessage("0_0000_0000_0000_0111_0000")));
+  EXPECT_THAT(res.events.GetAssertMessages(), IsEmpty());
+  EXPECT_THAT(res.events.GetTraceMessageStrings(),
+              ElementsAre("0_0000_0000_0000_0111_0000"));
 }
 
 TEST(TraceFmt, LeadingOneS32) {
@@ -91,10 +87,9 @@ TEST(TraceFmt, LeadingOneS32) {
   XLS_ASSERT_OK_AND_ASSIGN(InterpreterResult<Value> res,
                            trace->jit()->Run({input}));
 
-  EXPECT_THAT(res.events.assert_msgs, IsEmpty());
-  EXPECT_THAT(
-      res.events.trace_msgs,
-      ElementsAre(TraceMessage("1111_1111_1111_1111_1111_1111_1110_0000")));
+  EXPECT_THAT(res.events.GetAssertMessages(), IsEmpty());
+  EXPECT_THAT(res.events.GetTraceMessageStrings(),
+              ElementsAre("1111_1111_1111_1111_1111_1111_1110_0000"));
 }
 
 TEST(TraceFmt, ZeroPaddedS32) {
@@ -104,10 +99,9 @@ TEST(TraceFmt, ZeroPaddedS32) {
   XLS_ASSERT_OK_AND_ASSIGN(InterpreterResult<Value> res,
                            trace->jit()->Run({input}));
 
-  EXPECT_THAT(res.events.assert_msgs, IsEmpty());
-  EXPECT_THAT(
-      res.events.trace_msgs,
-      ElementsAre(TraceMessage("0000_0000_0000_0000_0000_0000_0111_0000")));
+  EXPECT_THAT(res.events.GetAssertMessages(), IsEmpty());
+  EXPECT_THAT(res.events.GetTraceMessageStrings(),
+              ElementsAre("0000_0000_0000_0000_0000_0000_0111_0000"));
 }
 
 TEST(TraceFmt, Enum) {
@@ -115,9 +109,9 @@ TEST(TraceFmt, Enum) {
   XLS_ASSERT_OK_AND_ASSIGN(InterpreterResult<Value> res,
                            trace->jit()->Run(absl::Span<Value>()));
 
-  EXPECT_THAT(res.events.assert_msgs, IsEmpty());
-  EXPECT_THAT(res.events.trace_msgs,
-              ElementsAre(TraceMessage("0_0000_0011_0000_0011_1001")));
+  EXPECT_THAT(res.events.GetAssertMessages(), IsEmpty());
+  EXPECT_THAT(res.events.GetTraceMessageStrings(),
+              ElementsAre("0_0000_0011_0000_0011_1001"));
 }
 
 TEST(TraceFmt, LeadingOne16Hex) {
@@ -127,8 +121,8 @@ TEST(TraceFmt, LeadingOne16Hex) {
   XLS_ASSERT_OK_AND_ASSIGN(InterpreterResult<Value> res,
                            trace->jit()->Run({input}));
 
-  EXPECT_THAT(res.events.assert_msgs, IsEmpty());
-  EXPECT_THAT(res.events.trace_msgs, ElementsAre(TraceMessage("ff00")));
+  EXPECT_THAT(res.events.GetAssertMessages(), IsEmpty());
+  EXPECT_THAT(res.events.GetTraceMessageStrings(), ElementsAre("ff00"));
 }
 
 TEST(TraceFmt, ZeroPadded16Hex) {
@@ -138,8 +132,8 @@ TEST(TraceFmt, ZeroPadded16Hex) {
   XLS_ASSERT_OK_AND_ASSIGN(InterpreterResult<Value> res,
                            trace->jit()->Run({input}));
 
-  EXPECT_THAT(res.events.assert_msgs, IsEmpty());
-  EXPECT_THAT(res.events.trace_msgs, ElementsAre(TraceMessage("0070")));
+  EXPECT_THAT(res.events.GetAssertMessages(), IsEmpty());
+  EXPECT_THAT(res.events.GetTraceMessageStrings(), ElementsAre("0070"));
 }
 
 TEST(TraceFmt, LeadingOne21Hex) {
@@ -149,8 +143,8 @@ TEST(TraceFmt, LeadingOne21Hex) {
   XLS_ASSERT_OK_AND_ASSIGN(InterpreterResult<Value> res,
                            trace->jit()->Run({input}));
 
-  EXPECT_THAT(res.events.assert_msgs, IsEmpty());
-  EXPECT_THAT(res.events.trace_msgs, ElementsAre(TraceMessage("1f_ff00")));
+  EXPECT_THAT(res.events.GetAssertMessages(), IsEmpty());
+  EXPECT_THAT(res.events.GetTraceMessageStrings(), ElementsAre("1f_ff00"));
 }
 
 TEST(TraceFmt, ZeroPadded21Hex) {
@@ -160,8 +154,8 @@ TEST(TraceFmt, ZeroPadded21Hex) {
   XLS_ASSERT_OK_AND_ASSIGN(InterpreterResult<Value> res,
                            trace->jit()->Run({input}));
 
-  EXPECT_THAT(res.events.assert_msgs, IsEmpty());
-  EXPECT_THAT(res.events.trace_msgs, ElementsAre(TraceMessage("0f_ff00")));
+  EXPECT_THAT(res.events.GetAssertMessages(), IsEmpty());
+  EXPECT_THAT(res.events.GetTraceMessageStrings(), ElementsAre("0f_ff00"));
 }
 }  // namespace
 }  // namespace xls

--- a/xls/interpreter/block_evaluator.cc
+++ b/xls/interpreter/block_evaluator.cc
@@ -450,12 +450,7 @@ BlockEvaluator::EvaluateChannelizedSequentialBlock(
 
     block_io_results.inputs.push_back(std::move(input_set));
     block_io_results.outputs.push_back(continuation->output_ports());
-    absl::c_copy(
-        continuation->events().assert_msgs,
-        std::back_inserter(block_io_results.interpreter_events.assert_msgs));
-    absl::c_copy(
-        continuation->events().trace_msgs,
-        std::back_inserter(block_io_results.interpreter_events.trace_msgs));
+    block_io_results.interpreter_events.AppendFrom(continuation->events());
   }
 
   return block_io_results;

--- a/xls/interpreter/block_evaluator_test_base.cc
+++ b/xls/interpreter/block_evaluator_test_base.cc
@@ -22,8 +22,6 @@
 #include <string_view>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
@@ -31,6 +29,8 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/types/span.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/module_signature.pb.h"
 #include "xls/common/status/matchers.h"
 #include "xls/common/status/status_macros.h"
@@ -1506,10 +1506,9 @@ TEST_P(BlockEvaluatorTest, InterpreterEventsCaptured) {
         .interpreter_events = cont->events(),
     };
 
-    EXPECT_THAT(result.interpreter_events.trace_msgs,
-                ElementsAre(FieldsAre("x is 10", 0),
-                            FieldsAre("I'm emphasizing that x is 10", 3)));
-    EXPECT_THAT(result.interpreter_events.assert_msgs, IsEmpty());
+    EXPECT_THAT(result.interpreter_events.GetTraceMessageStrings(),
+                ElementsAre("x is 10", "I'm emphasizing that x is 10"));
+    EXPECT_THAT(result.interpreter_events.GetAssertMessages(), IsEmpty());
   }
 
   {
@@ -1524,10 +1523,10 @@ TEST_P(BlockEvaluatorTest, InterpreterEventsCaptured) {
         .interpreter_events = cont->events(),
     };
 
-    EXPECT_THAT(result.interpreter_events.trace_msgs,
-                ElementsAre(FieldsAre("x is 3", 0),
-                            FieldsAre("I'm emphasizing that x is 3", 3)));
-    EXPECT_THAT(result.interpreter_events.assert_msgs, ElementsAre("foo"));
+    EXPECT_THAT(result.interpreter_events.GetTraceMessageStrings(),
+                ElementsAre("x is 3", "I'm emphasizing that x is 3"));
+    EXPECT_THAT(result.interpreter_events.GetAssertMessages(),
+                ElementsAre("foo"));
   }
 }
 
@@ -1577,12 +1576,11 @@ TEST_P(BlockEvaluatorTest, InterpreterEventsCapturedByChannelizedInterface) {
                              sinks.at(0).GetOutputSequenceAsUint64());
     EXPECT_GT(block_io.outputs.size(), output_sequence.size());
     EXPECT_THAT(output_sequence, ElementsAre(8, 7, 6, 5, 4));
-    EXPECT_THAT(block_io.interpreter_events.assert_msgs,
+    EXPECT_THAT(block_io.interpreter_events.GetAssertMessages(),
                 // Assertion fails for inputs 5 and 4.
                 ElementsAre("foo", "foo"));
-    EXPECT_THAT(block_io.interpreter_events.trace_msgs,
-                Contains(FieldsAre(HasSubstr("I'm emphasizing that x is "), _))
-                    .Times(5));
+    EXPECT_THAT(block_io.interpreter_events.GetTraceMessageStrings(),
+                Contains(HasSubstr("I'm emphasizing that x is ")).Times(5));
   }
 }
 

--- a/xls/interpreter/function_interpreter.cc
+++ b/xls/interpreter/function_interpreter.cc
@@ -89,16 +89,8 @@ absl::StatusOr<InterpreterResult<Value>> InterpretFunction(
   }
   FunctionInterpreter visitor(args, options, observer, call_depth);
   if (options.trace_calls()) {
-    std::vector<std::string> arg_strs;
-    arg_strs.reserve(args.size());
-    for (const Value& v : args) {
-      arg_strs.push_back(v.ToHumanString(options.format_preference()));
-    }
-    visitor.GetInterpreterEvents().trace_msgs.push_back(TraceMessage{
-        .message =
-            absl::StrFormat("%*s%s(%s)", 2 * call_depth, "", function->name(),
-                            absl::StrJoin(arg_strs, ", ")),
-        .verbosity = 0});
+    visitor.GetInterpreterEvents().AddTraceCallMessage(
+        function->name(), args, call_depth, options.format_preference());
   }
   XLS_RETURN_IF_ERROR(function->Accept(&visitor));
   Value result = visitor.ResolveAsValue(function->return_value());

--- a/xls/interpreter/ir_evaluator_test_base.h
+++ b/xls/interpreter/ir_evaluator_test_base.h
@@ -133,12 +133,9 @@ class IrEvaluatorTestBase
     XLS_ASSIGN_OR_RETURN(InterpreterResult<Value> result,
                          GetParam().evaluator(f, args, options, observer));
 
-    if (!result.events.trace_msgs.empty()) {
-      std::vector<std::string_view> trace_messages;
-      trace_messages.reserve(result.events.trace_msgs.size());
-      for (const TraceMessage& trace : result.events.trace_msgs) {
-        trace_messages.push_back(trace.message);
-      }
+    if (!result.events.GetTraceMessages().empty()) {
+      std::vector<std::string> trace_messages =
+          result.events.GetTraceMessageStrings();
       return absl::FailedPreconditionError(
           absl::StrFormat("Unexpected traces during RunWithNoEvents:\n%s",
                           absl::StrJoin(trace_messages, "\n")));
@@ -188,8 +185,8 @@ class IrEvaluatorTestBase
     XLS_ASSIGN_OR_RETURN(
         InterpreterResult<Value> result,
         GetParam().kwargs_evaluator(function, kwargs, options, std::nullopt));
-    XLS_RET_CHECK(result.events.trace_msgs.empty());
-    XLS_RET_CHECK(result.events.assert_msgs.empty());
+    XLS_RET_CHECK(result.events.GetTraceMessages().empty());
+    XLS_RET_CHECK(result.events.GetAssertMessages().empty());
     return result.value;
   }
 };

--- a/xls/interpreter/ir_interpreter.cc
+++ b/xls/interpreter/ir_interpreter.cc
@@ -91,14 +91,7 @@ absl::StatusOr<Value> InterpretNode(Node* node,
 
 absl::Status IrInterpreter::AddInterpreterEvents(
     const InterpreterEvents& events) {
-  for (const TraceMessage& trace_msg : events.trace_msgs) {
-    GetInterpreterEvents().trace_msgs.push_back(trace_msg);
-  }
-
-  for (const std::string& assert_msg : events.assert_msgs) {
-    GetInterpreterEvents().assert_msgs.push_back(assert_msg);
-  }
-
+  GetInterpreterEvents().AppendFrom(events);
   return absl::OkStatus();
 }
 
@@ -505,7 +498,7 @@ absl::Status IrInterpreter::HandleAssert(Assert* assert_op) {
   VLOG(2) << "Checking assert " << assert_op->ToString();
   VLOG(2) << "Condition is " << ResolveAsBool(assert_op->condition());
   if (!ResolveAsBool(assert_op->condition())) {
-    GetInterpreterEvents().assert_msgs.push_back(assert_op->message());
+    GetInterpreterEvents().AddAssertMessage(assert_op->message());
   }
   return SetValueResult(assert_op, Value::Token());
 }
@@ -548,10 +541,8 @@ absl::Status IrInterpreter::HandleTrace(Trace* trace_op) {
 
     VLOG(3) << "Trace output: " << trace_output;
 
-    GetInterpreterEvents().trace_msgs.push_back(TraceMessage{
-        .message = trace_output,
-        .verbosity = trace_op->verbosity(),
-    });
+    GetInterpreterEvents().AddTraceStatementMessage(trace_op->verbosity(),
+                                                    trace_output);
   }
   return SetValueResult(trace_op, Value::Token());
 }

--- a/xls/interpreter/proc_runtime.cc
+++ b/xls/interpreter/proc_runtime.cc
@@ -60,8 +60,7 @@ class ChannelTraceRecorder : public ChannelQueueCallback {
                                           channel_instance->ToString(),
                                           value.ToString(format_preference_));
     VLOG(3) << message;
-    runtime_->AddTraceMessage(
-        TraceMessage{.message = std::move(message), .verbosity = 0});
+    runtime_->AddTraceMessage(0, std::move(message));
   }
 
   void WriteValue(ChannelInstance* channel_instance,
@@ -70,8 +69,7 @@ class ChannelTraceRecorder : public ChannelQueueCallback {
                                           channel_instance->ToString(),
                                           value.ToString(format_preference_));
     VLOG(3) << message;
-    runtime_->AddTraceMessage(
-        TraceMessage{.message = std::move(message), .verbosity = 0});
+    runtime_->AddTraceMessage(0, std::move(message));
   }
 
  private:
@@ -262,9 +260,9 @@ void ProcRuntime::ClearInterpreterEvents() {
   }
 }
 
-void ProcRuntime::AddTraceMessage(TraceMessage message) {
+void ProcRuntime::AddTraceMessage(int64_t verbosity, std::string message) {
   absl::MutexLock lock(&global_events_mutex_);
-  global_events_.trace_msgs.push_back(std::move(message));
+  global_events_.AddTraceStatementMessage(verbosity, std::move(message));
 }
 
 }  // namespace xls

--- a/xls/interpreter/proc_runtime.h
+++ b/xls/interpreter/proc_runtime.h
@@ -144,7 +144,7 @@ class ProcRuntime {
 
  protected:
   friend class ChannelTraceRecorder;
-  void AddTraceMessage(TraceMessage message);
+  void AddTraceMessage(int64_t verbosity, std::string message);
 
   // Execute (up to) a single iteration of every proc in the package.
   struct NetworkTickResult {

--- a/xls/interpreter/proc_runtime_test_base.cc
+++ b/xls/interpreter/proc_runtime_test_base.cc
@@ -20,12 +20,12 @@
 #include <string_view>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/common/status/matchers.h"
 #include "xls/common/status/status_macros.h"
 #include "xls/interpreter/channel_queue.h"
@@ -1112,13 +1112,8 @@ TEST_P(ProcRuntimeTestBase, TraceChannels) {
     XLS_ASSERT_OK(runtime->TickUntilBlocked(/*max_ticks=*/100));
 
     InterpreterEvents events = runtime->GetGlobalEvents();
-    std::vector<std::string> event_messages;
-    event_messages.reserve(events.trace_msgs.size());
-    for (const TraceMessage& message : events.trace_msgs) {
-      event_messages.push_back(message.message);
-    }
     EXPECT_THAT(
-        event_messages,
+        events.GetTraceMessageStrings(),
         ElementsAre(ContainsRegex("Sent data on channel `in`.*:42"),
                     ContainsRegex("Sent data on channel `in`.*:123"),
                     ContainsRegex("Received data on channel `in`.*:42"),
@@ -1139,13 +1134,8 @@ TEST_P(ProcRuntimeTestBase, TraceChannels) {
     XLS_ASSERT_OK(runtime->TickUntilBlocked(/*max_ticks=*/100));
 
     InterpreterEvents events = runtime->GetGlobalEvents();
-    std::vector<std::string> event_messages;
-    event_messages.reserve(events.trace_msgs.size());
-    for (const TraceMessage& message : events.trace_msgs) {
-      event_messages.push_back(message.message);
-    }
     EXPECT_THAT(
-        event_messages,
+        events.GetTraceMessageStrings(),
         ElementsAre(ContainsRegex("Sent data on channel `in`.*:0x2a"),
                     ContainsRegex("Sent data on channel `in`.*:0x7b"),
                     ContainsRegex("Received data on channel `in`.*:0x2a"),
@@ -1163,7 +1153,7 @@ TEST_P(ProcRuntimeTestBase, TraceChannels) {
     XLS_ASSERT_OK(in_queue.Write({Value(UBits(123, 32))}));
     XLS_ASSERT_OK(in_queue.Write({Value(UBits(100, 32))}));
     XLS_ASSERT_OK(runtime->TickUntilBlocked(/*max_ticks=*/100));
-    EXPECT_TRUE(runtime->GetGlobalEvents().trace_msgs.empty());
+    EXPECT_TRUE(runtime->GetGlobalEvents().GetTraceMessages().empty());
   }
 }
 

--- a/xls/ir/BUILD
+++ b/xls/ir/BUILD
@@ -570,9 +570,14 @@ cc_library(
     srcs = ["events.cc"],
     hdrs = ["events.h"],
     deps = [
+        ":evaluator_result_cc_proto",
+        ":format_preference",
+        ":value",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -1485,6 +1490,22 @@ py_proto_library(
     name = "xls_value_py_pb2",
     visibility = ["//xls:xls_users"],
     deps = [":xls_value_proto"],
+)
+
+proto_library(
+    name = "evaluator_result_proto",
+    srcs = ["evaluator_result.proto"],
+    deps = [":xls_value_proto"],
+)
+
+cc_proto_library(
+    name = "evaluator_result_cc_proto",
+    deps = [":evaluator_result_proto"],
+)
+
+py_proto_library(
+    name = "evaluator_result_py_pb2",
+    deps = [":evaluator_result_proto"],
 )
 
 proto_library(

--- a/xls/ir/evaluator_result.proto
+++ b/xls/ir/evaluator_result.proto
@@ -1,0 +1,70 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package xls;
+
+import "xls/ir/xls_value.proto";
+
+
+// Metadata about a message from a trace statement.
+message TraceStatementProto {
+  optional int64 verbosity = 1;
+}
+
+// Message metadata for a function call when call tracing is enabled.
+message TraceCallProto {
+  optional string function_name = 1;
+  repeated ValueProto args = 2;
+  optional int64 call_depth = 3;
+}
+
+// Message metadata for a node value when node valuetracing is enabled.
+message TraceNodeProto {
+  optional string node_name = 1;
+  optional int64 node_id = 2;
+  optional ValueProto value_changes = 3;
+}   
+
+// A trace message emitted during evaluation.
+message TraceMessageProto {
+  optional string message = 1;
+  oneof type {
+    TraceStatementProto statement = 2;
+    TraceCallProto call = 3;
+    TraceNodeProto node = 4;
+  }
+}
+
+// An assertion message emitted during evaluation.
+message AssertMessageProto {
+  string message = 1;
+}
+
+message EvaluatorEventsProto {
+  repeated TraceMessageProto trace_msgs = 1;
+  repeated AssertMessageProto assert_msgs = 2;
+}
+
+// Result of evaluating a function.
+// TODO(meheff): Add support for proc/block evaluation.
+message EvaluatorResultProto {
+  ValueProto result = 1;
+  EvaluatorEventsProto events = 2;
+}
+
+message EvaluatorResultsProto {
+  repeated EvaluatorResultProto results = 1;
+}

--- a/xls/ir/events.cc
+++ b/xls/ir/events.cc
@@ -19,13 +19,13 @@
 namespace xls {
 
 absl::Status InterpreterEventsToStatus(const InterpreterEvents& events) {
-  if (events.assert_msgs.empty()) {
+  if (events.GetAssertMessages().empty()) {
     return absl::OkStatus();
   }
 
   // If an assertion has been raised, return the message from the first
   // assertion recorded, matching the behavior of short-circuit evaluation.
-  return absl::AbortedError(events.assert_msgs.front());
+  return absl::AbortedError(events.GetAssertMessages().front());
 }
 
 }  // namespace xls

--- a/xls/ir/events.h
+++ b/xls/ir/events.h
@@ -15,57 +15,96 @@
 #ifndef XLS_IR_EVENTS_H_
 #define XLS_IR_EVENTS_H_
 
-#include <compare>
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/types/span.h"
+#include "xls/ir/evaluator_result.pb.h"
+#include "xls/ir/format_preference.h"
+#include "xls/ir/value.h"
 
 namespace xls {
 
-// A trace message is a string and a verbosity associated with the message.
-struct TraceMessage {
-  std::string message;
-  int64_t verbosity;
-
-  bool operator==(const TraceMessage& other) const {
-    return message == other.message && verbosity == other.verbosity;
-  }
-  bool operator!=(const TraceMessage& other) const { return !(*this == other); }
-  std::strong_ordering operator<=>(const TraceMessage& other) const {
-    auto verbosity_cmp = verbosity <=> other.verbosity;
-    if (verbosity_cmp != std::strong_ordering::equal) {
-      return verbosity_cmp;
-    }
-    return message <=> other.message;
-  }
-
-  template <typename Sink>
-  friend void AbslStringify(Sink& sink, const TraceMessage& t) {
-    absl::Format(&sink, "%s [verbosity: %d]", t.message, t.verbosity);
-  }
-};
-
 // Common structure capturing events that can be produced by any XLS interpreter
 // (DSLX, IR, JIT, etc.)
-struct InterpreterEvents {
-  std::vector<TraceMessage> trace_msgs;
-  std::vector<std::string> assert_msgs;
-
-  void Clear() {
-    trace_msgs.clear();
-    assert_msgs.clear();
+class InterpreterEvents {
+ public:
+  void AddTraceStatementMessage(int64_t verbosity, std::string msg) {
+    TraceMessageProto* tm = proto_.add_trace_msgs();
+    tm->set_message(std::move(msg));
+    tm->mutable_statement()->set_verbosity(verbosity);
   }
 
+  void AddTraceCallMessage(std::string_view function_name,
+                           absl::Span<const Value> args, int64_t call_depth,
+                           FormatPreference format_preference) {
+    TraceMessageProto* tm = proto_.add_trace_msgs();
+    // Build an indented message like: "  foo(1, 2, 3)".
+    tm->set_message(absl::StrFormat(
+        "%*s%s(%s)", call_depth * 2, "", function_name,
+        absl::StrJoin(args, ", ",
+                      [format_preference](std::string* out, const Value& v) {
+                        out->append(v.ToHumanString(format_preference));
+                      })));
+    tm->mutable_call()->set_function_name(std::string{function_name});
+    tm->mutable_call()->set_call_depth(call_depth);
+    for (const Value& v : args) {
+      *tm->mutable_call()->add_args() = v.AsProto().value();
+    }
+  }
+  void AddAssertMessage(const std::string& msg) {
+    proto_.add_assert_msgs()->set_message(msg);
+  }
+
+  const ::google::protobuf::RepeatedPtrField<TraceMessageProto>&
+  GetTraceMessages() const {
+    return proto_.trace_msgs();
+  }
+  std::vector<std::string> GetTraceMessageStrings() const {
+    std::vector<std::string> messages;
+    messages.reserve(proto_.trace_msgs_size());
+    for (const TraceMessageProto& t : proto_.trace_msgs()) {
+      messages.push_back(t.message());
+    }
+    return messages;
+  }
+  std::vector<std::string> GetAssertMessages() const {
+    std::vector<std::string> asserts;
+    asserts.reserve(proto_.assert_msgs_size());
+    for (const AssertMessageProto& a : proto_.assert_msgs()) {
+      asserts.push_back(a.message());
+    }
+    return asserts;
+  }
+
+  void Clear() { proto_.Clear(); }
+
   bool operator==(const InterpreterEvents& other) const {
-    return trace_msgs == other.trace_msgs && assert_msgs == other.assert_msgs;
+    return proto_.SerializeAsString() == other.proto_.SerializeAsString();
   }
   bool operator!=(const InterpreterEvents& other) const {
     return !(*this == other);
   }
+
+  void AppendFrom(const InterpreterEvents& other) {
+    for (const TraceMessageProto& t : other.proto_.trace_msgs()) {
+      *proto_.add_trace_msgs() = t;
+    }
+    for (const AssertMessageProto& a : other.proto_.assert_msgs()) {
+      *proto_.add_assert_msgs() = a;
+    }
+  }
+
+  const EvaluatorEventsProto& AsProto() const { return proto_; }
+
+ private:
+  EvaluatorEventsProto proto_;
 };
 // Convert an InterpreterEvents structure into a result status, returning
 // a failure when an assertion has been raised.

--- a/xls/jit/function_jit_aot_test.cc
+++ b/xls/jit/function_jit_aot_test.cc
@@ -132,9 +132,8 @@ TEST_F(FunctionJitAotTest, CallAot) {
   {
     XLS_ASSERT_OK_AND_ASSIGN(auto res, test_aot->Run({Value(UBits(3, 8))}));
     EXPECT_EQ(res.value, Value(UBits(15, 8)));
-    EXPECT_THAT(res.events.trace_msgs,
-                UnorderedElementsAre(TraceMessage("mf_2(6) -> 12", 0),
-                                     TraceMessage("mf_1(3) -> 15", 0)));
+    EXPECT_THAT(res.events.GetTraceMessageStrings(),
+                UnorderedElementsAre("mf_2(6) -> 12", "mf_1(3) -> 15"));
   }
 
   // Packed
@@ -205,10 +204,9 @@ TEST_F(FunctionJitAotTest, InterceptCallAot) {
   {
     XLS_ASSERT_OK_AND_ASSIGN(auto res, test_aot->Run({Value(UBits(3, 8))}));
     EXPECT_EQ(res.value, Value(UBits(15, 8)));
-    EXPECT_THAT(res.events.trace_msgs,
-                UnorderedElementsAre(TraceMessage("Stuck in the middle", 42),
-                                     TraceMessage("mf_2(6) -> 12", 0),
-                                     TraceMessage("mf_1(3) -> 15", 0)));
+    EXPECT_THAT(res.events.GetTraceMessageStrings(),
+                UnorderedElementsAre("Stuck in the middle", "mf_2(6) -> 12",
+                                     "mf_1(3) -> 15"));
     EXPECT_EQ(called_unpacked_cnt, 1);
     EXPECT_EQ(called_packed_cnt, 0);
   }

--- a/xls/jit/jit_callbacks.cc
+++ b/xls/jit/jit_callbacks.cc
@@ -54,8 +54,7 @@ void PerformFormatStep(InstanceContext* thiz, JitRuntime* runtime,
 
 void RecordTrace(InstanceContext* thiz, std::string* buffer, int64_t verbosity,
                  InterpreterEvents* events) {
-  events->trace_msgs.push_back(
-      TraceMessage{.message = *buffer, .verbosity = verbosity});
+  events->AddTraceStatementMessage(verbosity, *buffer);
   delete buffer;
 }
 std::string* CreateTraceBuffer(InstanceContext* thiz) {
@@ -63,7 +62,7 @@ std::string* CreateTraceBuffer(InstanceContext* thiz) {
 }
 void RecordAssertion(InstanceContext* thiz, const char* msg,
                      InterpreterEvents* events) {
-  events->assert_msgs.push_back(msg);
+  events->AddAssertMessage(msg);
 }
 
 bool QueueReceiveWrapper(InstanceContext* thiz, int64_t queue_index,

--- a/xls/jit/jit_wrapper_test.cc
+++ b/xls/jit/jit_wrapper_test.cc
@@ -18,11 +18,11 @@
 #include <optional>
 #include <string_view>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/algorithm/container.h"
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/common/status/matchers.h"
 #include "xls/dslx/stdlib/float32_mul_jit_wrapper.h"
 #include "xls/dslx/stdlib/tests/float32_upcast_jit_wrapper.h"
@@ -323,11 +323,9 @@ TEST(JitWrapperTest, BlockTraceEventsWork) {
       something::cool::MultiFuncWithTraceBlockJitPorts().SetX(
           3)));  // After the pipeline is flushed, 5*3 will be the output.
   XLS_ASSERT_OK(jit->RunOneCycle(*cont));
-  EXPECT_THAT(cont->interpreter_events().assert_msgs, IsEmpty());
-  EXPECT_THAT(
-      cont->interpreter_events().trace_msgs,
-      ElementsAre(TraceMessage{.message = "mf_2(2) -> 4", .verbosity = 0},
-                  TraceMessage{.message = "mf_1(1) -> 5", .verbosity = 0}));
+  EXPECT_THAT(cont->interpreter_events().GetAssertMessages(), IsEmpty());
+  EXPECT_THAT(cont->interpreter_events().GetTraceMessageStrings(),
+              ElementsAre("mf_2(2) -> 4", "mf_1(1) -> 5"));
 }
 
 }  // namespace

--- a/xls/modules/aes/aes_ctr_test.cc
+++ b/xls/modules/aes/aes_ctr_test.cc
@@ -78,10 +78,11 @@ static void IvToBuffer(const InitVector& iv,
 }
 
 static void PrintTraceMessages(const InterpreterEvents& events) {
-  if (absl::GetFlag(FLAGS_print_traces) && !events.trace_msgs.empty()) {
+  if (absl::GetFlag(FLAGS_print_traces) &&
+      events.GetTraceMessages().size() > 0) {
     std::cout << "Trace messages:" << '\n';
-    for (const auto& tm : events.trace_msgs) {
-      std::cout << " - " << tm.message << '\n';
+    for (const auto& tm : events.GetTraceMessages()) {
+      std::cout << " - " << tm.message() << '\n';
     }
   }
 }

--- a/xls/public/c_api.cc
+++ b/xls/public/c_api.cc
@@ -1286,17 +1286,23 @@ bool xls_function_jit_run(struct xls_function_jit* jit, size_t argc,
     return false;
   }
 
+  const auto& trace_msgs = result->events.GetTraceMessages();
   std::unique_ptr<xls_trace_message[]> trace_messages =
-      std::make_unique<xls_trace_message[]>(result->events.trace_msgs.size());
-  for (size_t i = 0; i < result->events.trace_msgs.size(); ++i) {
-    trace_messages[i].message =
-        xls::ToOwnedCString(result->events.trace_msgs[i].message);
-    trace_messages[i].verbosity = result->events.trace_msgs[i].verbosity;
+      std::make_unique<xls_trace_message[]>(trace_msgs.size());
+  for (int i = 0; i < trace_msgs.size(); ++i) {
+    const xls::TraceMessageProto& tm = trace_msgs[i];
+    trace_messages[i].message = xls::ToOwnedCString(tm.message());
+    int64_t verbosity = 0;
+    if (tm.has_statement()) {
+      verbosity = tm.statement().verbosity();
+    }
+    trace_messages[i].verbosity = verbosity;
   }
   *trace_messages_out = trace_messages.release();
-  *trace_messages_count_out = result->events.trace_msgs.size();
+  *trace_messages_count_out = trace_msgs.size();
 
-  xls::ToOwnedCStrings(result->events.assert_msgs, assert_messages_out,
+  std::vector<std::string> assert_msgs = result->events.GetAssertMessages();
+  xls::ToOwnedCStrings(assert_msgs, assert_messages_out,
                        assert_messages_count_out);
 
   *result_out = reinterpret_cast<struct xls_value*>(

--- a/xls/tools/BUILD
+++ b/xls/tools/BUILD
@@ -206,6 +206,7 @@ cc_binary(
         "//xls/interpreter:random_value",
         "//xls/ir",
         "//xls/ir:bits",
+        "//xls/ir:evaluator_result_cc_proto",
         "//xls/ir:events",
         "//xls/ir:format_preference",
         "//xls/ir:ir_parser",
@@ -232,6 +233,7 @@ cc_binary(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:span",
+        "@com_google_protobuf//:protobuf",
         "@llvm-project//llvm:CodeGen",
         "@llvm-project//llvm:ExecutionEngine",
         "@llvm-project//llvm:IRReader",
@@ -901,9 +903,11 @@ py_test(
         ":node_coverage_stats_py_pb2",
         "//xls/common:runfiles",
         "//xls/common:test_base",
+        "//xls/ir:evaluator_result_py_pb2",
         "//xls/ir:xls_value_py_pb2",
         "@abseil-py//absl/testing:absltest",
         "@abseil-py//absl/testing:parameterized",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )
 

--- a/xls/tools/eval_ir_main.cc
+++ b/xls/tools/eval_ir_main.cc
@@ -37,6 +37,7 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "absl/types/span.h"
+#include "google/protobuf/text_format.h"
 #include "llvm/include/llvm/ADT/APInt.h"
 #include "llvm/include/llvm/ADT/StringRef.h"
 #include "llvm/include/llvm/CodeGen/CommandFlags.h"
@@ -80,6 +81,7 @@
 #include "xls/interpreter/observer.h"
 #include "xls/interpreter/random_value.h"
 #include "xls/ir/bits.h"
+#include "xls/ir/evaluator_result.pb.h"
 #include "xls/ir/events.h"
 #include "xls/ir/format_preference.h"
 #include "xls/ir/function.h"
@@ -192,6 +194,11 @@ ABSL_FLAG(bool, test_llvm_jit, false,
 ABSL_FLAG(int64_t, llvm_opt_level, 3,
           "The optimization level of the LLVM JIT. Valid values are from 0 (no "
           "optimizations) to 3 (maximum optimizations).");
+ABSL_FLAG(std::string, output_results_proto, "",
+          "If non-empty, write a text EvaluatorResultsProto (one entry per "
+          "argset) to the given file path.");
+ABSL_FLAG(bool, trace_to_stderr, false,
+          "If true, write trace messages to stderr.");
 ABSL_FLAG(std::string, input_validator_expr, "",
           "DSLX expression to validate randomly-generated inputs. "
           "The expression can reference entry function input arguments "
@@ -386,7 +393,8 @@ absl::StatusOr<std::vector<Value>> Eval(
     Function* f, absl::Span<const ArgSet> arg_sets, bool use_jit,
     std::optional<EvaluationObserver*> eval_observer = std::nullopt,
     std::string_view actual_src = "actual",
-    std::string_view expected_src = "expected") {
+    std::string_view expected_src = "expected",
+    EvaluatorResultsProto* results_out = nullptr) {
   EvalIrJitObserver observer(absl::GetFlag(FLAGS_use_llvm_jit_interpreter));
   std::unique_ptr<FunctionJit> jit;
   if (use_jit) {
@@ -402,15 +410,15 @@ absl::StatusOr<std::vector<Value>> Eval(
 
   std::vector<Value> results;
   for (const ArgSet& arg_set : arg_sets) {
-    Value result;
+    InterpreterResult<Value> run_res;
     if (use_jit) {
       if (absl::GetFlag(FLAGS_test_only_inject_jit_result).empty()) {
         if (absl::GetFlag(FLAGS_use_llvm_jit_interpreter)) {
           XLS_RET_CHECK(!eval_observer)
               << "Observer not supported with llvm interpreter.";
-          XLS_ASSIGN_OR_RETURN(result, DropInterpreterEvents(RunLlvmInterpreter(
-                                           f, observer.saved_opt_ir(),
-                                           jit.get(), arg_set.args)));
+          XLS_ASSIGN_OR_RETURN(
+              run_res, RunLlvmInterpreter(f, observer.saved_opt_ir(), jit.get(),
+                                          arg_set.args));
         } else {
           std::optional<RuntimeEvaluationObserverAdapter> adapt;
           if (eval_observer) {
@@ -422,35 +430,42 @@ absl::StatusOr<std::vector<Value>> Eval(
                 jit->runtime());
             XLS_RETURN_IF_ERROR(jit->SetRuntimeObserver(&adapt.value()));
           }
-          XLS_ASSIGN_OR_RETURN(result,
-                               DropInterpreterEvents(jit->Run(arg_set.args)));
+          XLS_ASSIGN_OR_RETURN(run_res, jit->Run(arg_set.args));
           jit->ClearRuntimeObserver();
         }
       } else {
-        XLS_ASSIGN_OR_RETURN(result, Parser::ParseTypedValue(absl::GetFlag(
-                                         FLAGS_test_only_inject_jit_result)));
+        XLS_ASSIGN_OR_RETURN(
+            Value inj, Parser::ParseTypedValue(
+                           absl::GetFlag(FLAGS_test_only_inject_jit_result)));
+        run_res = InterpreterResult<Value>{std::move(inj), InterpreterEvents{}};
       }
     } else {
-      // TODO(https://github.com/google/xls/issues/506): 2021-10-12 Also compare
-      // resulting events once the JIT fully supports events. Note: This will
-      // require rethinking some of the control flow because event comparison
-      // only makes sense for certain modes (optimize_ir and test_llvm_jit).
       XLS_ASSIGN_OR_RETURN(
-          result, DropInterpreterEvents(InterpretFunction(
-                      f, arg_set.args, EvaluatorOptions(), eval_observer)));
+          run_res, InterpretFunction(f, arg_set.args, EvaluatorOptions(),
+                                     eval_observer));
     }
-    std::cout << result.ToString(FormatPreference::kHex) << '\n';
+    if (absl::GetFlag(FLAGS_trace_to_stderr)) {
+      for (const std::string& msg : run_res.events.GetTraceMessageStrings()) {
+        std::cerr << msg << '\n';
+      }
+    }
+    if (results_out != nullptr) {
+      EvaluatorResultProto* entry = results_out->add_results();
+      *entry->mutable_result() = run_res.value.AsProto().value();
+      *entry->mutable_events() = run_res.events.AsProto();
+    }
+    std::cout << run_res.value.ToString(FormatPreference::kHex) << '\n';
 
     if (arg_set.expected.has_value()) {
-      if (result != *arg_set.expected) {
+      if (run_res.value != *arg_set.expected) {
         return absl::InvalidArgumentError(absl::StrFormat(
             "Miscompare for input[%i] \"%s\"\n  %s: %s\n  %s: %s",
             results.size(), ArgsToString(arg_set.args), actual_src,
-            result.ToString(FormatPreference::kHex), expected_src,
+            run_res.value.ToString(FormatPreference::kHex), expected_src,
             arg_set.expected->ToString(FormatPreference::kHex)));
       }
     }
-    results.push_back(result);
+    results.push_back(run_res.value);
   }
   return results;
 }
@@ -512,10 +527,21 @@ absl::Status Run(Package* package, absl::Span<const ArgSet> arg_sets_in) {
           << "Cannot specify expected values when using --test_llvm_jit";
       arg_sets[i].expected = interpreter_results[i];
     }
+    EvaluatorResultsProto results_proto;
+    EvaluatorResultsProto* out_ptr =
+        absl::GetFlag(FLAGS_output_results_proto).empty() ? nullptr
+                                                          : &results_proto;
     XLS_RETURN_IF_ERROR(Eval(f, arg_sets, /*use_jit=*/true,
                              /*eval_observer=*/cov.observer(), "JIT",
-                             "interpreter")
+                             "interpreter", out_ptr)
                             .status());
+    if (out_ptr != nullptr) {
+      std::string text;
+      XLS_RET_CHECK(
+          google::protobuf::TextFormat::PrintToString(*out_ptr, &text));
+      XLS_RETURN_IF_ERROR(
+          SetFileContents(absl::GetFlag(FLAGS_output_results_proto), text));
+    }
     return absl::OkStatus();
   }
 
@@ -523,9 +549,14 @@ absl::Status Run(Package* package, absl::Span<const ArgSet> arg_sets_in) {
   // results as the expected values if the expected value is not already
   // set. These expected values are used in any later evaluation after
   // optimizations.
+  EvaluatorResultsProto results_proto;
+  EvaluatorResultsProto* out_ptr =
+      absl::GetFlag(FLAGS_output_results_proto).empty() ? nullptr
+                                                        : &results_proto;
   XLS_ASSIGN_OR_RETURN(
       std::vector<Value> results,
-      Eval(f, arg_sets, absl::GetFlag(FLAGS_use_llvm_jit), cov.observer()));
+      Eval(f, arg_sets, absl::GetFlag(FLAGS_use_llvm_jit), cov.observer(),
+           /*actual_src=*/"actual", /*expected_src=*/"expected", out_ptr));
   for (int64_t i = 0; i < arg_sets.size(); ++i) {
     if (!arg_sets[i].expected.has_value()) {
       arg_sets[i].expected = results[i];
@@ -557,11 +588,17 @@ absl::Status Run(Package* package, absl::Span<const ArgSet> arg_sets_in) {
 
     XLS_RETURN_IF_ERROR(Eval(f, arg_sets, absl::GetFlag(FLAGS_use_llvm_jit),
                              cov.observer(), "after optimizations",
-                             "before optimizations")
+                             "before optimizations", /*results_out=*/nullptr)
                             .status());
   } else {
     XLS_RET_CHECK(!absl::GetFlag(FLAGS_eval_after_each_pass))
         << "Must specify --optimize_ir with --eval_after_each_pass";
+  }
+  if (out_ptr != nullptr) {
+    std::string text;
+    XLS_RET_CHECK(google::protobuf::TextFormat::PrintToString(*out_ptr, &text));
+    XLS_RETURN_IF_ERROR(
+        SetFileContents(absl::GetFlag(FLAGS_output_results_proto), text));
   }
   return absl::OkStatus();
 }

--- a/xls/tools/eval_ir_main_test.py
+++ b/xls/tools/eval_ir_main_test.py
@@ -22,6 +22,8 @@ from xls.common import runfiles
 from xls.common import test_base
 from xls.ir import xls_value_pb2
 from xls.tools import node_coverage_stats_pb2
+from google.protobuf import text_format
+from xls.ir import evaluator_result_pb2
 
 EVAL_IR_MAIN_PATH = runfiles.get_path('xls/tools/eval_ir_main')
 
@@ -263,6 +265,64 @@ class EvalMainTest(parameterized.TestCase):
     self.assertLen(result.decode('utf-8').strip().split('\n'), 42)
     # And with overwhelming probability they should all be different.
     self.assertLen(set(result.decode('utf-8').strip().split('\n')), 42)
+
+  def test_output_results_proto_with_trace(self):
+    trace_ir = """package foo
+
+top fn foo(x: bits[8]) -> bits[8] {
+  tkn: token = literal(value=token)
+  on: bits[1] = literal(value=1)
+  trace.1: token = trace(tkn, on, format="x is {:x}", data_operands=[x])
+  ret identity.2: bits[8] = identity(x)
+}
+"""
+    ir_file = self.create_tempfile(content=trace_ir)
+    out = self.create_tempfile()
+    result = subprocess.check_output([
+        EVAL_IR_MAIN_PATH,
+        '--nouse_llvm_jit',
+        '--input=bits[8]:0x2a',
+        f'--output_results_proto={out.full_path}',
+        ir_file.full_path,
+    ])
+    self.assertEqual(result.decode('utf-8').strip(), 'bits[8]:0x2a')
+    # Parse textproto and verify trace message
+    results_proto = evaluator_result_pb2.EvaluatorResultsProto()
+    text_format.Parse(out.read_text(), results_proto)
+    self.assertLen(results_proto.results, 1)
+    # Verify result matches bits[8]:0x2a
+    res = results_proto.results[0].result
+    self.assertTrue(res.HasField('bits'))
+    self.assertEqual(res.bits.bit_count, 8)
+    self.assertEqual(res.bits.data, struct.pack('b', 0x2A))
+    self.assertGreaterEqual(len(results_proto.results[0].events.trace_msgs), 1)
+    self.assertEqual(
+        results_proto.results[0].events.trace_msgs[0].message, 'x is 2a'
+    )
+
+  def test_trace_to_stderr(self):
+    trace_ir = """package foo
+
+top fn foo(x: bits[8]) -> bits[8] {
+  tkn: token = literal(value=token)
+  on: bits[1] = literal(value=1)
+  trace.1: token = trace(tkn, on, format="x is {:x}", data_operands=[x])
+  ret identity.2: bits[8] = identity(x)
+}
+"""
+    ir_file = self.create_tempfile(content=trace_ir)
+    comp = subprocess.run(
+        [
+            EVAL_IR_MAIN_PATH,
+            '--nouse_llvm_jit',
+            '--input=bits[8]:0x2a',
+            '--trace_to_stderr',
+            ir_file.full_path,
+        ],
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    self.assertIn('x is 2a', comp.stderr.decode('utf-8'))
 
   def test_jit_result_injection(self):
     ir_file = self.create_tempfile(content=ADD_IR)


### PR DESCRIPTION
Use a newly defined proto as the backing storage for InterpreterEvents. This enables more structured trace messages such as those created by --trace_calls. In generaly, this will help with introspection of evaluator state. Also, add a flag for dumping the proto to file in eval_ir_main. Also add a flag --trace_to_stderr which emits traces to stderr.