### PR TITLE
Fix bazel build for all platforms

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,6 +27,8 @@ build --incompatible_default_to_explicit_init_py=true
 # starting with macOS 10.15.
 build:macos --host_macos_minimum_os=10.15
 build:macos --macos_minimum_os=10.15
+# Keep local macOS exec-config compiles on the same standard as the release path.
+build:macos --cxxopt "-std=c++20"      --host_cxxopt "-std=c++20"
 
 # Depending on the installation, clang or clang-tidy need to be told that
 # a c++ file is, indeed, containing c++ (bazel just invokes clang, not clang++)

--- a/.github/workflows/build-and-release-dylib.yml
+++ b/.github/workflows/build-and-release-dylib.yml
@@ -284,7 +284,7 @@ jobs:
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh 18
-        sudo apt-get install -y clang-18 libc++-18-dev libc++abi-18-dev
+        sudo apt-get install -y clang-18 libc++-18-dev libc++abi-18-dev libtinfo5
 
     - name: Install zlib development headers
       run: |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,17 +4,24 @@ module(
 )
 
 # Compiler toolchain
-# bazel_dep(name = "toolchains_llvm", version = "1.4.0")
+bazel_dep(name = "toolchains_llvm", version = "1.4.0")
 
 # Configure and register the toolchain.
-# llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
-# llvm.toolchain(
-#     llvm_version = "19.1.7",
-#     cxx_standard = {"": "c++20"},
-# )
-# use_repo(llvm, "llvm_toolchain")
-#
-# register_toolchains("@llvm_toolchain//:all")
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm.toolchain(
+    cxx_standard = {"": "c++20"},
+    llvm_versions = {
+        "": "19.1.7",
+        "darwin-aarch64": "19.1.7",
+        "darwin-x86_64": "19.1.7",
+        "linux-x86_64": "18.1.8",
+        "ubuntu-20.04-x86_64": "18.1.8",
+        "ubuntu-24.04-x86_64": "19.1.7",
+    },
+)
+use_repo(llvm, "llvm_toolchain")
+
+register_toolchains("@llvm_toolchain//:all")
 
 # Python toolchain
 # TODO: https://github.com/google/xls/issues/2941 - revisit versioning once we're on bazel 8.
@@ -116,6 +123,14 @@ maven.artifact(
 # Used both by XLS and rules_hdl.
 bazel_dep(name = "eigen", version = "4.0.0-20241125.bcr.2")
 bazel_dep(name = "rules_pkg", version = "1.2.0")
+
+# Bazel's generated macOS wrapped_clang currently fails dyld without LC_UUID.
+single_version_override(
+    module_name = "apple_support",
+    version = "1.17.1",
+    patch_strip = 1,
+    patches = ["//dependency_support:apple_support_no_uuid.patch"],
+)
 
 # Workaround suggested by a Bazel team member; only needed for WORKSPACE to work correctly.
 # TODO: https://github.com/google/xls/issues/931 - Remove this workaround once the WORKSPACE file is migrated to MODULE.bazel.

--- a/dependency_support/apple_support_no_uuid.patch
+++ b/dependency_support/apple_support_no_uuid.patch
@@ -1,0 +1,211 @@
+diff --git a/crosstool/osx_cc_configure.bzl b/crosstool/osx_cc_configure.bzl
+index 1307b53..a963578 100644
+--- a/crosstool/osx_cc_configure.bzl
++++ b/crosstool/osx_cc_configure.bzl
+@@ -102,7 +102,6 @@ def _compile_cc_file(repository_ctx, src_name, out_name):
+         "arm64",
+         "-arch",
+         "x86_64",
+         "-Wl,-no_adhoc_codesign",
+-        "-Wl,-no_uuid",
+         "-O3",
+         "-o",
+         out_name,
+
+diff --git a/crosstool/cc_toolchain_config.bzl b/crosstool/cc_toolchain_config.bzl
+--- a/crosstool/cc_toolchain_config.bzl
++++ b/crosstool/cc_toolchain_config.bzl
+@@ -1498,25 +1498,26 @@
+                     ACTION_NAMES.cpp_link_static_library,
+                     ACTION_NAMES.linkstamp_compile,
+                 ],
+-                env_entries = [
+-                    env_entry(
+-                        key = "XCODE_VERSION_OVERRIDE",
+-                        value = str(xcode_config.xcode_version()),
+-                    ),
+-                    # TODO: Remove once we drop bazel 7.x support
+-                    env_entry(
+-                        key = "APPLE_SDK_VERSION_OVERRIDE",
+-                        value = str(sdk_version),
+-                    ),
+-                    env_entry(
+-                        key = "APPLE_SDK_PLATFORM",
+-                        value = _sdk_name(platform_type, is_simulator),
+-                    ),
+-                    env_entry(
+-                        key = "ZERO_AR_DATE",
+-                        value = "1",
+-                    ),
+-                ] + [env_entry(key = key, value = value) for key, value in ctx.attr.extra_env.items()],
++                env_entries = (
++                    ([env_entry(
++                        key = "XCODE_VERSION_OVERRIDE",
++                        value = str(xcode_config.xcode_version()),
++                    )] if xcode_config.xcode_version() else []) +
++                    # TODO: Remove once we drop bazel 7.x support
++                    ([env_entry(
++                        key = "APPLE_SDK_VERSION_OVERRIDE",
++                        value = str(sdk_version),
++                    )] if xcode_config.xcode_version() and sdk_version else []) + [
++                        env_entry(
++                            key = "APPLE_SDK_PLATFORM",
++                            value = _sdk_name(platform_type, is_simulator),
++                        ),
++                        env_entry(
++                            key = "ZERO_AR_DATE",
++                            value = "1",
++                        ),
++                    ] + [env_entry(key = key, value = value) for key, value in ctx.attr.extra_env.items()]
++                ),
+             ),
+         ],
+     )
+
+diff --git a/crosstool/libtool.sh b/crosstool/libtool.sh
+--- a/crosstool/libtool.sh
++++ b/crosstool/libtool.sh
+@@ -33,12 +33,22 @@
+ fi
+
+ function invoke_libtool() {
+-  # Just invoke libtool via xcrunwrapper
+-  "${MY_LOCATION}/xcrunwrapper.sh" libtool "$@" \
+-  2> >(grep -v "the table of contents is empty (no object file members in the"`
+-              `" library define global symbols)$" >&2)
+-  # ^ Filtering a warning that's unlikely to indicate a real issue
+-  # ...and not silencable via a flag.
++  local stderr_file
++  stderr_file="$(mktemp "${TMPDIR:-/tmp}/libtool.stderr.XXXXXXXX")"
++  local status=0
++
++  # Just invoke libtool via xcrunwrapper.
++  "${MY_LOCATION}/xcrunwrapper.sh" libtool "$@" 2>"${stderr_file}" || status=$?
++
++  # Filter a warning that's unlikely to indicate a real issue and is not
++  # silencable via a flag, without relying on bash process substitution.
++  if [[ -s "${stderr_file}" ]]; then
++    grep -v "the table of contents is empty (no object file members in the library define global symbols)$" \
++      "${stderr_file}" >&2 || true
++  fi
++
++  rm -f "${stderr_file}"
++  return "${status}"
+ }
+
+ if [ ! -f "${MY_LOCATION}"/libtool_check_unique ] ; then
+diff --git a/crosstool/wrapped_clang.cc b/crosstool/wrapped_clang.cc
+--- a/crosstool/wrapped_clang.cc
++++ b/crosstool/wrapped_clang.cc
+@@ -168,13 +168,11 @@
+   return false;
+ }
+ 
+-// Returns the DEVELOPER_DIR environment variable in the current process
+-// environment. Aborts if this variable is unset.
+-std::string GetMandatoryEnvVar(const std::string &var_name) {
++// Returns the requested environment variable or an empty string if it is unset.
++std::string GetEnvVar(const std::string &var_name) {
+   char *env_value = getenv(var_name.c_str());
+   if (env_value == nullptr) {
+-    std::cerr << "Error: " << var_name << " not set.\n";
+-    exit(EXIT_FAILURE);
++    return "";
+   }
+   return env_value;
+ }
+@@ -309,6 +307,14 @@
+       result += buffer.data();
+     }
+     return result;
++}
++
++std::string TrimTrailingNewlines(std::string value) {
++  while (!value.empty() &&
++         (value.back() == '\n' || value.back() == '\r')) {
++    value.pop_back();
++  }
++  return value;
+ }
+ 
+ std::string GetToolchainPath(const std::string &toolchain_id) {
+@@ -421,8 +427,32 @@
+     toolchain_path = GetToolchainPath(toolchain_id);
+   }
+ 
+-  std::string developer_dir = GetMandatoryEnvVar("DEVELOPER_DIR");
+-  std::string sdk_root = GetMandatoryEnvVar("SDKROOT");
++  std::string developer_dir = GetEnvVar("DEVELOPER_DIR");
++  if (developer_dir.empty()) {
++    developer_dir = TrimTrailingNewlines(exec("/usr/bin/xcode-select -p"));
++    if (developer_dir.empty()) {
++      std::cerr << "Error: failed to determine DEVELOPER_DIR via xcode-select.\n";
++      exit(EXIT_FAILURE);
++    }
++  }
++  std::string sdk_root = GetEnvVar("SDKROOT");
++  if (sdk_root.empty() || !std::filesystem::exists(sdk_root)) {
++    std::string previous_developer_dir = GetEnvVar("DEVELOPER_DIR");
++    setenv("DEVELOPER_DIR", developer_dir.c_str(), 1);
++    sdk_root =
++        TrimTrailingNewlines(exec("/usr/bin/xcrun --sdk macosx --show-sdk-path"));
++    if (previous_developer_dir.empty()) {
++      unsetenv("DEVELOPER_DIR");
++    } else {
++      setenv("DEVELOPER_DIR", previous_developer_dir.c_str(), 1);
++    }
++    if (sdk_root.empty()) {
++      std::cerr << "Error: failed to determine SDKROOT via xcrun.\n";
++      exit(EXIT_FAILURE);
++    }
++  }
++  setenv("DEVELOPER_DIR", developer_dir.c_str(), 1);
++  setenv("SDKROOT", sdk_root.c_str(), 1);
+   std::string linked_binary, dsym_path;
+ 
+   const std::string cwd = GetCurrentDirectory();
+diff --git a/crosstool/xcrunwrapper.sh b/crosstool/xcrunwrapper.sh
+--- a/crosstool/xcrunwrapper.sh
++++ b/crosstool/xcrunwrapper.sh
+@@ -32,12 +32,18 @@
+ if [[ -z "${WRAPPER_DEVDIR}" ]] ; then
+   WRAPPER_DEVDIR="$(xcode-select -p)"
+ fi
++WRAPPER_SDKROOT="${SDKROOT:-}"
++if [[ -z "${WRAPPER_SDKROOT}" || ! -d "${WRAPPER_SDKROOT}" ]] ; then
++  WRAPPER_SDKROOT="$(DEVELOPER_DIR="${WRAPPER_DEVDIR}" /usr/bin/xcrun --sdk macosx --show-sdk-path)"
++fi
++export DEVELOPER_DIR="${WRAPPER_DEVDIR}"
++export SDKROOT="${WRAPPER_SDKROOT}"
+ 
+ # Substitute toolkit path placeholders.
+ UPDATEDARGS=()
+ for ARG in "$@" ; do
+   ARG="${ARG//__BAZEL_XCODE_DEVELOPER_DIR__/${WRAPPER_DEVDIR}}"
+-  ARG="${ARG//__BAZEL_XCODE_SDKROOT__/${SDKROOT}}"
++  ARG="${ARG//__BAZEL_XCODE_SDKROOT__/${WRAPPER_SDKROOT}}"
+   UPDATEDARGS+=("${ARG}")
+ done
+ 
+diff --git a/lib/apple_support.bzl b/lib/apple_support.bzl
+--- a/lib/apple_support.bzl
++++ b/lib/apple_support.bzl
+@@ -188,10 +188,14 @@
+ 
+     # Add the environment variables required for DEVELOPER_DIR and SDKROOT last to avoid clients
+     # overriding these values.
+-    merged_env.update(apple_common.apple_host_system_env(xcode_config))
+-    merged_env.update(
+-        apple_common.target_apple_env(xcode_config, apple_fragment.single_arch_platform),
+-    )
++    host_env = apple_common.apple_host_system_env(xcode_config)
++    merged_env.update(host_env)
++    if host_env:
++        merged_env.update(
++            apple_common.target_apple_env(xcode_config, apple_fragment.single_arch_platform),
++        )
++    else:
++        merged_env["APPLE_SDK_PLATFORM"] = apple_fragment.single_arch_platform.name_in_plist
+ 
+     merged_execution_requirements = {}
+     original_execution_requirements = processed_args.get("execution_requirements")

--- a/make_local_release.py
+++ b/make_local_release.py
@@ -274,9 +274,19 @@ def main():
     if options.macos:
         # Tests do not work on MacOS because static initializers of the estimators are
         # stripped out which breaks the build.
-        make_local_release(output_dir, MACOS_TARGETS, run_tests=False, mode=options.mode)
+        make_local_release(
+            output_dir,
+            MACOS_TARGETS,
+            run_tests=False,
+            mode=options.mode,
+        )
     else:
-        make_local_release(output_dir, LINUX_TARGETS, run_tests=True, mode=options.mode)
+        make_local_release(
+            output_dir,
+            LINUX_TARGETS,
+            run_tests=True,
+            mode=options.mode,
+        )
 
 if __name__ == "__main__":
     main()

--- a/xls/codegen/combinational_generator_test.cc
+++ b/xls/codegen/combinational_generator_test.cc
@@ -2098,6 +2098,12 @@ TEST_P(CombinationalGeneratorTest, SDiv) {
   EXPECT_THAT(simulator.RunAndReturnSingleOutput(
                   {{"x", SBits(-10, 32)}, {"y", SBits(7, 32)}}),
               IsOkAndHolds(SBits(-1, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(10, 32)}, {"y", SBits(-7, 32)}}),
+              IsOkAndHolds(SBits(-1, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-10, 32)}, {"y", SBits(-7, 32)}}),
+              IsOkAndHolds(SBits(1, 32)));
 
   // Test overflow condition.
   EXPECT_THAT(simulator.RunAndReturnSingleOutput(
@@ -2114,6 +2120,110 @@ TEST_P(CombinationalGeneratorTest, SDiv) {
   EXPECT_THAT(simulator.RunAndReturnSingleOutput(
                   {{"x", SBits(-12345, 32)}, {"y", SBits(0, 32)}}),
               IsOkAndHolds(Bits::MinSigned(32)));
+
+  ExpectVerilogEqualToGoldenFile(GoldenFilePath(kTestName, kTestdataPath),
+                                 result.verilog_text);
+}
+
+TEST_P(CombinationalGeneratorTest, UMod) {
+  Package package(TestBaseName());
+  FunctionBuilder fb(TestBaseName(), &package);
+  BValue x = fb.Param("x", package.GetBitsType(32));
+  BValue y = fb.Param("y", package.GetBitsType(32));
+  fb.UMod(x, y);
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(auto result,
+                           GenerateCombinationalModule(f, codegen_options()));
+
+  ModuleSimulator simulator =
+      NewModuleSimulator(result.verilog_text, result.signature);
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", UBits(42, 32)}, {"y", UBits(7, 32)}}),
+              IsOkAndHolds(UBits(0, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", UBits(10, 32)}, {"y", UBits(7, 32)}}),
+              IsOkAndHolds(UBits(3, 32)));
+  // Mod by zero should return zero.
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", UBits(0, 32)}, {"y", UBits(0, 32)}}),
+              IsOkAndHolds(UBits(0, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", UBits(12345, 32)}, {"y", UBits(0, 32)}}),
+              IsOkAndHolds(UBits(0, 32)));
+
+  ExpectVerilogEqualToGoldenFile(GoldenFilePath(kTestName, kTestdataPath),
+                                 result.verilog_text);
+}
+
+TEST_P(CombinationalGeneratorTest, SMod) {
+  Package package(TestBaseName());
+  FunctionBuilder fb(TestBaseName(), &package);
+  BValue x = fb.Param("x", package.GetBitsType(32));
+  BValue y = fb.Param("y", package.GetBitsType(32));
+  fb.SMod(x, y);
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(auto result,
+                           GenerateCombinationalModule(f, codegen_options()));
+
+  ModuleSimulator simulator =
+      NewModuleSimulator(result.verilog_text, result.signature);
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(42, 32)}, {"y", SBits(7, 32)}}),
+              IsOkAndHolds(SBits(0, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-10, 32)}, {"y", SBits(7, 32)}}),
+              IsOkAndHolds(SBits(-3, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(10, 32)}, {"y", SBits(-7, 32)}}),
+              IsOkAndHolds(SBits(3, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(100, 32)}, {"y", SBits(-7, 32)}}),
+              IsOkAndHolds(SBits(2, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-100, 32)}, {"y", SBits(-7, 32)}}),
+              IsOkAndHolds(SBits(-2, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", Bits::MinSigned(32)}, {"y", SBits(-1, 32)}}),
+              IsOkAndHolds(SBits(0, 32)));
+  // Mod by zero should return zero.
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(0, 32)}, {"y", SBits(0, 32)}}),
+              IsOkAndHolds(SBits(0, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(12345, 32)}, {"y", SBits(0, 32)}}),
+              IsOkAndHolds(SBits(0, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-12345, 32)}, {"y", SBits(0, 32)}}),
+              IsOkAndHolds(SBits(0, 32)));
+
+  ExpectVerilogEqualToGoldenFile(GoldenFilePath(kTestName, kTestdataPath),
+                                 result.verilog_text);
+}
+
+TEST_P(CombinationalGeneratorTest, SModSmallWidthNegativeDivisor) {
+  Package package(TestBaseName());
+  FunctionBuilder fb(TestBaseName(), &package);
+  BValue x = fb.Param("x", package.GetBitsType(4));
+  BValue y = fb.Param("y", package.GetBitsType(4));
+  fb.SMod(x, y);
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(auto result,
+                           GenerateCombinationalModule(f, codegen_options()));
+
+  ModuleSimulator simulator =
+      NewModuleSimulator(result.verilog_text, result.signature);
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(3, 4)}, {"y", SBits(-2, 4)}}),
+              IsOkAndHolds(SBits(1, 4)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-3, 4)}, {"y", SBits(-2, 4)}}),
+              IsOkAndHolds(SBits(-1, 4)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", Bits::MinSigned(4)}, {"y", SBits(-1, 4)}}),
+              IsOkAndHolds(SBits(0, 4)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-3, 4)}, {"y", SBits(0, 4)}}),
+              IsOkAndHolds(Bits(4)));
 
   ExpectVerilogEqualToGoldenFile(GoldenFilePath(kTestName, kTestdataPath),
                                  result.verilog_text);

--- a/xls/codegen/module_builder.cc
+++ b/xls/codegen/module_builder.cc
@@ -625,6 +625,8 @@ bool ModuleBuilder::CanEmitAsInlineExpression(Node* node) {
     case Op::kUMulp:
     case Op::kSDiv:
     case Op::kUDiv:
+    case Op::kSMod:
+    case Op::kUMod:
       return false;
     default:
       break;
@@ -1469,6 +1471,8 @@ bool ModuleBuilder::MustEmitAsFunction(Node* node) {
     case Op::kBitSliceUpdate:
     case Op::kSDiv:
     case Op::kUDiv:
+    case Op::kSMod:
+    case Op::kUMod:
     case Op::kShra:
       return true;
     case Op::kPrioritySel:
@@ -1508,6 +1512,8 @@ absl::StatusOr<std::string> ModuleBuilder::VerilogFunctionName(Node* node) {
     }
     case Op::kSDiv:
     case Op::kUDiv:
+    case Op::kSMod:
+    case Op::kUMod:
       CHECK_EQ(node->BitCountOrDie(), node->operand(0)->BitCountOrDie());
       CHECK_EQ(node->BitCountOrDie(), node->operand(1)->BitCountOrDie());
       return absl::StrFormat("%s_%db", OpToString(node->op()),
@@ -1957,6 +1963,73 @@ VerilogFunction* DefineSDivFunction(Node* node, std::string_view function_name,
   return func;
 }
 
+// Defines and returns a function which implements the given UMod node.
+VerilogFunction* DefineUModFunction(Node* node, std::string_view function_name,
+                                    ModuleSection* section) {
+  CHECK_EQ(node->op(), Op::kUMod);
+  VerilogFile* file = section->file();
+
+  VerilogFunction* func = section->Add<VerilogFunction>(
+      node->loc(), function_name,
+      file->BitVectorType(node->BitCountOrDie(), node->loc()));
+  CHECK_EQ(node->operand_count(), 2);
+  Expression* lhs = func->AddArgument(
+      "lhs",
+      file->BitVectorType(node->operand(0)->BitCountOrDie(), node->loc()),
+      node->loc());
+  Expression* rhs = func->AddArgument(
+      "rhs",
+      file->BitVectorType(node->operand(1)->BitCountOrDie(), node->loc()),
+      node->loc());
+  Expression* rhs_is_zero = file->Equals(
+      rhs,
+      file->Literal(UBits(0, node->operand(1)->BitCountOrDie()), node->loc()),
+      node->loc());
+  Expression* zero =
+      file->Literal(UBits(0, node->BitCountOrDie()), node->loc());
+  func->AddStatement<BlockingAssignment>(
+      node->loc(), func->return_value_ref(),
+      file->Ternary(rhs_is_zero, zero, file->Mod(lhs, rhs, node->loc()),
+                    node->loc()));
+  return func;
+}
+
+// Defines and returns a function which implements the given SMod node.
+VerilogFunction* DefineSModFunction(Node* node, std::string_view function_name,
+                                    ModuleSection* section) {
+  CHECK_EQ(node->op(), Op::kSMod);
+  VerilogFile* file = section->file();
+
+  VerilogFunction* func = section->Add<VerilogFunction>(
+      node->loc(), function_name,
+      file->BitVectorType(node->BitCountOrDie(), node->loc()));
+  CHECK_EQ(node->operand_count(), 2);
+  Expression* lhs = func->AddArgument(
+      "lhs",
+      file->BitVectorType(node->operand(0)->BitCountOrDie(), node->loc()),
+      node->loc());
+  Expression* rhs = func->AddArgument(
+      "rhs",
+      file->BitVectorType(node->operand(1)->BitCountOrDie(), node->loc()),
+      node->loc());
+  Expression* rhs_is_zero = file->Equals(
+      rhs,
+      file->Literal(UBits(0, node->operand(1)->BitCountOrDie()), node->loc()),
+      node->loc());
+  Expression* zero =
+      file->Literal(UBits(0, node->BitCountOrDie()), node->loc());
+
+  // Wrap the expression in $unsigned to prevent signedness from leaking out.
+  Expression* modulo = file->Make<UnsignedCast>(
+      node->loc(),
+      file->Mod(file->Make<SignedCast>(node->loc(), lhs),
+                file->Make<SignedCast>(node->loc(), rhs), node->loc()));
+  func->AddStatement<BlockingAssignment>(
+      node->loc(), func->return_value_ref(),
+      file->Ternary(rhs_is_zero, zero, modulo, node->loc()));
+  return func;
+}
+
 VerilogFunction* DefineShraFunction(Node* node, std::string_view function_name,
                                     ModuleSection* section) {
   CHECK_EQ(node->op(), Op::kShra);
@@ -2067,6 +2140,12 @@ absl::StatusOr<VerilogFunction*> ModuleBuilder::DefineFunction(Node* node) {
       break;
     case Op::kSDiv:
       func = DefineSDivFunction(node, function_name, functions_section_);
+      break;
+    case Op::kUMod:
+      func = DefineUModFunction(node, function_name, functions_section_);
+      break;
+    case Op::kSMod:
+      func = DefineSModFunction(node, function_name, functions_section_);
       break;
     case Op::kShra:
       func = DefineShraFunction(node, function_name, functions_section_);

--- a/xls/codegen/testdata/combinational_generator_test_SMod.vtxt
+++ b/xls/codegen/testdata/combinational_generator_test_SMod.vtxt
@@ -1,0 +1,14 @@
+module SMod(
+  input wire [31:0] x,
+  input wire [31:0] y,
+  output wire [31:0] out
+);
+  function automatic [31:0] smod_32b (input reg [31:0] lhs, input reg [31:0] rhs);
+    begin
+      smod_32b = rhs == 32'h0000_0000 ? 32'h0000_0000 : $unsigned($signed(lhs) % $signed(rhs));
+    end
+  endfunction
+  wire [31:0] smod_6;
+  assign smod_6 = smod_32b(x, y);
+  assign out = smod_6;
+endmodule

--- a/xls/codegen/testdata/combinational_generator_test_SModSmallWidthNegativeDivisor.vtxt
+++ b/xls/codegen/testdata/combinational_generator_test_SModSmallWidthNegativeDivisor.vtxt
@@ -1,0 +1,14 @@
+module SModSmallWidthNegativeDivisor(
+  input wire [3:0] x,
+  input wire [3:0] y,
+  output wire [3:0] out
+);
+  function automatic [3:0] smod_4b (input reg [3:0] lhs, input reg [3:0] rhs);
+    begin
+      smod_4b = rhs == 4'h0 ? 4'h0 : $unsigned($signed(lhs) % $signed(rhs));
+    end
+  endfunction
+  wire [3:0] smod_6;
+  assign smod_6 = smod_4b(x, y);
+  assign out = smod_6;
+endmodule

--- a/xls/codegen/testdata/combinational_generator_test_UMod.vtxt
+++ b/xls/codegen/testdata/combinational_generator_test_UMod.vtxt
@@ -1,0 +1,14 @@
+module UMod(
+  input wire [31:0] x,
+  input wire [31:0] y,
+  output wire [31:0] out
+);
+  function automatic [31:0] umod_32b (input reg [31:0] lhs, input reg [31:0] rhs);
+    begin
+      umod_32b = rhs == 32'h0000_0000 ? 32'h0000_0000 : lhs % rhs;
+    end
+  endfunction
+  wire [31:0] umod_6;
+  assign umod_6 = umod_32b(x, y);
+  assign out = umod_6;
+endmodule

--- a/xls/codegen_v_1_5/codegen_combinational_function_test.cc
+++ b/xls/codegen_v_1_5/codegen_combinational_function_test.cc
@@ -2140,6 +2140,12 @@ TEST_P(CodegenCombinationalFunctionTest, SDiv) {
   EXPECT_THAT(simulator.RunAndReturnSingleOutput(
                   {{"x", SBits(-10, 32)}, {"y", SBits(7, 32)}}),
               IsOkAndHolds(SBits(-1, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(10, 32)}, {"y", SBits(-7, 32)}}),
+              IsOkAndHolds(SBits(-1, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-10, 32)}, {"y", SBits(-7, 32)}}),
+              IsOkAndHolds(SBits(1, 32)));
 
   // Test overflow condition.
   EXPECT_THAT(simulator.RunAndReturnSingleOutput(
@@ -2156,6 +2162,93 @@ TEST_P(CodegenCombinationalFunctionTest, SDiv) {
   EXPECT_THAT(simulator.RunAndReturnSingleOutput(
                   {{"x", SBits(-12345, 32)}, {"y", SBits(0, 32)}}),
               IsOkAndHolds(Bits::MinSigned(32)));
+
+  ExpectVerilogEqualToGoldenFile(GoldenFilePath(kTestName, kTestdataPath),
+                                 result.verilog_text);
+}
+
+TEST_P(CodegenCombinationalFunctionTest, SMod) {
+  Package package(TestBaseName());
+  FunctionBuilder fb(TestBaseName(), &package);
+  BValue x = fb.Param("x", package.GetBitsType(32));
+  BValue y = fb.Param("y", package.GetBitsType(32));
+  fb.SMod(x, y);
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(auto result,
+                           GenerateCombinationalModule(f, codegen_options()));
+
+  verilog::ModuleSimulator simulator =
+      NewModuleSimulator(result.verilog_text, result.signature);
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(42, 32)}, {"y", SBits(7, 32)}}),
+              IsOkAndHolds(SBits(0, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-42, 32)}, {"y", SBits(7, 32)}}),
+              IsOkAndHolds(SBits(0, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(42, 32)}, {"y", SBits(-7, 32)}}),
+              IsOkAndHolds(SBits(0, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-42, 32)}, {"y", SBits(-7, 32)}}),
+              IsOkAndHolds(SBits(0, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(10, 32)}, {"y", SBits(7, 32)}}),
+              IsOkAndHolds(SBits(3, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-10, 32)}, {"y", SBits(7, 32)}}),
+              IsOkAndHolds(SBits(-3, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(10, 32)}, {"y", SBits(-7, 32)}}),
+              IsOkAndHolds(SBits(3, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(100, 32)}, {"y", SBits(-7, 32)}}),
+              IsOkAndHolds(SBits(2, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-100, 32)}, {"y", SBits(-7, 32)}}),
+              IsOkAndHolds(SBits(-2, 32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", Bits::MinSigned(32)}, {"y", SBits(-1, 32)}}),
+              IsOkAndHolds(SBits(0, 32)));
+
+  // Mod by zero should return zero.
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(0, 32)}, {"y", SBits(0, 32)}}),
+              IsOkAndHolds(Bits(32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(12345, 32)}, {"y", SBits(0, 32)}}),
+              IsOkAndHolds(Bits(32)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-12345, 32)}, {"y", SBits(0, 32)}}),
+              IsOkAndHolds(Bits(32)));
+
+  ExpectVerilogEqualToGoldenFile(GoldenFilePath(kTestName, kTestdataPath),
+                                 result.verilog_text);
+}
+
+TEST_P(CodegenCombinationalFunctionTest, SModSmallWidthNegativeDivisor) {
+  Package package(TestBaseName());
+  FunctionBuilder fb(TestBaseName(), &package);
+  BValue x = fb.Param("x", package.GetBitsType(4));
+  BValue y = fb.Param("y", package.GetBitsType(4));
+  fb.SMod(x, y);
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(auto result,
+                           GenerateCombinationalModule(f, codegen_options()));
+
+  verilog::ModuleSimulator simulator =
+      NewModuleSimulator(result.verilog_text, result.signature);
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(3, 4)}, {"y", SBits(-2, 4)}}),
+              IsOkAndHolds(SBits(1, 4)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-3, 4)}, {"y", SBits(-2, 4)}}),
+              IsOkAndHolds(SBits(-1, 4)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", Bits::MinSigned(4)}, {"y", SBits(-1, 4)}}),
+              IsOkAndHolds(SBits(0, 4)));
+  EXPECT_THAT(simulator.RunAndReturnSingleOutput(
+                  {{"x", SBits(-3, 4)}, {"y", SBits(0, 4)}}),
+              IsOkAndHolds(Bits(4)));
 
   ExpectVerilogEqualToGoldenFile(GoldenFilePath(kTestName, kTestdataPath),
                                  result.verilog_text);

--- a/xls/codegen_v_1_5/testdata/codegen_combinational_function_test_SMod.vtxt
+++ b/xls/codegen_v_1_5/testdata/codegen_combinational_function_test_SMod.vtxt
@@ -1,0 +1,14 @@
+module SMod(
+  input wire [31:0] x,
+  input wire [31:0] y,
+  output wire [31:0] out
+);
+  function automatic [31:0] smod_32b (input reg [31:0] lhs, input reg [31:0] rhs);
+    begin
+      smod_32b = rhs == 32'h0000_0000 ? 32'h0000_0000 : $unsigned($signed(lhs) % $signed(rhs));
+    end
+  endfunction
+  wire [31:0] smod_15;
+  assign smod_15 = smod_32b(x, y);
+  assign out = smod_15;
+endmodule

--- a/xls/codegen_v_1_5/testdata/codegen_combinational_function_test_SModSmallWidthNegativeDivisor.vtxt
+++ b/xls/codegen_v_1_5/testdata/codegen_combinational_function_test_SModSmallWidthNegativeDivisor.vtxt
@@ -1,0 +1,14 @@
+module SModSmallWidthNegativeDivisor(
+  input wire [3:0] x,
+  input wire [3:0] y,
+  output wire [3:0] out
+);
+  function automatic [3:0] smod_4b (input reg [3:0] lhs, input reg [3:0] rhs);
+    begin
+      smod_4b = rhs == 4'h0 ? 4'h0 : $unsigned($signed(lhs) % $signed(rhs));
+    end
+  endfunction
+  wire [3:0] smod_15;
+  assign smod_15 = smod_4b(x, y);
+  assign out = smod_15;
+endmodule

--- a/xls/ir/interval_ops.cc
+++ b/xls/ir/interval_ops.cc
@@ -584,7 +584,7 @@ IntervalSet PerformVariadicOp(Calculate calc,
   }
 
   result_intervals.Normalize();
-  return MinimizeIntervals(result_intervals, /*size=*/16);
+  return MinimizeIntervals(result_intervals, /*size=*/kMaxExactCalculations);
 }
 
 template <typename Calculate>
@@ -1116,6 +1116,63 @@ IntervalSet Truncate(const IntervalSet& a, int64_t width) {
 }
 IntervalSet BitSlice(const IntervalSet& a, int64_t start, int64_t width) {
   return Truncate(Shrl(a, IntervalSet::Precise(UBits(start, 64))), width);
+}
+
+IntervalSet DynamicBitSlice(const IntervalSet& to_slice,
+                            const IntervalSet& start, int64_t width) {
+  if (to_slice.IsEmpty() || start.IsEmpty()) {
+    return IntervalSet(width);
+  }
+  CHECK(to_slice.IsNormalized());
+  CHECK(start.IsNormalized());
+
+  const int64_t input_width = to_slice.BitCount();
+
+  // Fast path: if the start index is precise, we can compute the result
+  // directly.
+  if (start.IsPrecise()) {
+    const int64_t shift_amount =
+        bits_ops::UnsignedBitsToSaturatedInt64(*start.GetPreciseValue());
+    if (shift_amount >= input_width) {
+      return IntervalSet::Precise(UBits(0, width));
+    }
+    return BitSlice(to_slice, shift_amount, width);
+  }
+
+  // Exact path: enumerate possible start indices when the set is small enough.
+  if (std::optional<int64_t> sz = start.Size();
+      sz.has_value() && *sz <= kMaxExactCalculations) {
+    IntervalSet result(width);
+    for (const Bits& s : start.Values()) {
+      const int64_t shift_amount = bits_ops::UnsignedBitsToSaturatedInt64(s);
+      IntervalSet sliced = (shift_amount >= input_width)
+                               ? IntervalSet::Precise(UBits(0, width))
+                               : BitSlice(to_slice, shift_amount, width);
+      result = IntervalSet::Combine(result, sliced);
+      result.Normalize();
+      if (result.IsMaximal()) {
+        return result;
+      }
+    }
+    result.Normalize();
+    // Avoid unbounded growth if the union gets too large.
+    if (result.NumberOfIntervals() > kMaxExactCalculations) {
+      result = MinimizeIntervals(std::move(result),
+                                 /*size=*/kMaxExactCalculations);
+    }
+    return result;
+  }
+
+  // If the start is always large enough to overshift, the result is always 0.
+  if (std::optional<Bits> start_lb = start.LowerBound(); start_lb.has_value()) {
+    const int64_t min_shift = bits_ops::UnsignedBitsToSaturatedInt64(*start_lb);
+    if (min_shift >= input_width) {
+      return IntervalSet::Precise(UBits(0, width));
+    }
+  }
+
+  // Conservative fallback: if the start set is large, avoid enumeration.
+  return IntervalSet::Maximal(width);
 }
 
 IntervalSet Concat(absl::Span<IntervalSet const> sets) {

--- a/xls/ir/interval_ops.h
+++ b/xls/ir/interval_ops.h
@@ -120,6 +120,8 @@ IntervalSet SignExtend(const IntervalSet& a, int64_t width);
 IntervalSet ZeroExtend(const IntervalSet& a, int64_t width);
 IntervalSet Truncate(const IntervalSet& a, int64_t width);
 IntervalSet BitSlice(const IntervalSet& a, int64_t start, int64_t width);
+IntervalSet DynamicBitSlice(const IntervalSet& to_slice,
+                            const IntervalSet& start, int64_t width);
 
 // Cmp
 IntervalSet Eq(const IntervalSet& a, const IntervalSet& b);

--- a/xls/ir/interval_ops_test.cc
+++ b/xls/ir/interval_ops_test.cc
@@ -1001,6 +1001,35 @@ FUZZ_TEST(IntervalOpsTest, BitSliceZ3Fuzz)
     .WithDomains(IntervalDomain(8), fuzztest::InRange<int8_t>(1, 15),
                  fuzztest::InRange<int8_t>(1, 15));
 
+TEST(IntervalOpsTest, DynamicBitSlice) {
+  IntervalSet x = FromRanges({{10, 200}}, 8);
+  IntervalSet start = FromValues({0, 2, 7, 8}, 4);
+
+  IntervalSet expected(4);
+  expected = IntervalSet::Combine(expected, interval_ops::BitSlice(x, 0, 4));
+  expected = IntervalSet::Combine(expected, interval_ops::BitSlice(x, 2, 4));
+  expected = IntervalSet::Combine(expected, interval_ops::BitSlice(x, 7, 4));
+  expected = IntervalSet::Combine(expected, IntervalSet::Precise(UBits(0, 4)));
+  expected.Normalize();
+
+  EXPECT_EQ(interval_ops::DynamicBitSlice(x, start, /*width=*/4), expected);
+}
+
+void DynamicBitSliceZ3Fuzz(absl::Span<std::pair<int64_t, int64_t> const> lhs,
+                           absl::Span<std::pair<int64_t, int64_t> const> rhs) {
+  BinaryOpFuzz(
+      "dynamic_bit_slice",
+      [](FunctionBuilder& fb, BValue l, BValue r) {
+        return fb.DynamicBitSlice(l, r, /*width=*/4);
+      },
+      [](const IntervalSet& l, const IntervalSet& r) {
+        return interval_ops::DynamicBitSlice(l, r, /*width=*/4);
+      },
+      lhs, rhs, /*bits=*/8);
+}
+FUZZ_TEST(IntervalOpsTest, DynamicBitSliceZ3Fuzz)
+    .WithDomains(IntervalDomain(8), IntervalDomain(8));
+
 void EqZ3Fuzz(absl::Span<std::pair<int64_t, int64_t> const> lhs,
               absl::Span<std::pair<int64_t, int64_t> const> rhs) {
   BinaryOpFuzz(

--- a/xls/ir/node_util.h
+++ b/xls/ir/node_util.h
@@ -69,6 +69,73 @@ inline bool IsLiteralZero(Node* node) {
          node->As<Literal>()->value().bits().IsZero();
 }
 
+// A uniform view of a bits-typed node that represents a zero-extension of a
+// narrower bits-typed `base` value.
+//
+// This matches either:
+// - `zero_ext(base, new_bit_count=W)` where base has width N < W
+// - `concat(0..., base)` where all leading operands are literal zeros and base
+//   is the final operand.
+struct ZeroExtendedBitsView {
+  // The original value being extended.
+  Node* base;
+  // Bit width of `base`.
+  int64_t base_width;
+  // Bit width of the zero-extended result (i.e. the node being matched).
+  int64_t result_width;
+  // Number of leading zero bits added (result_width - base_width).
+  int64_t leading_zero_width;
+};
+
+// Returns a view if `node` is a zero extension of a narrower bits value, as
+// defined by `ZeroExtendedBitsView`.
+inline std::optional<ZeroExtendedBitsView> MatchZeroExtendedBits(Node* node) {
+  if (node == nullptr || !node->GetType()->IsBits()) {
+    return std::nullopt;
+  }
+  const int64_t result_width = node->BitCountOrDie();
+
+  if (node->op() == Op::kZeroExt) {
+    ExtendOp* ext = node->As<ExtendOp>();
+    Node* base = ext->operand(0);
+    const int64_t base_width = base->BitCountOrDie();
+    if (base_width < result_width) {
+      return ZeroExtendedBitsView{
+          .base = base,
+          .base_width = base_width,
+          .result_width = result_width,
+          .leading_zero_width = result_width - base_width};
+    }
+    return std::nullopt;
+  }
+
+  if (node->op() == Op::kConcat) {
+    Concat* concat = node->As<Concat>();
+    if (concat->operand_count() < 2) {
+      return std::nullopt;
+    }
+    int64_t prefix_width = 0;
+    for (int64_t i = 0; i < concat->operand_count() - 1; ++i) {
+      Node* prefix = concat->operand(i);
+      if (!IsLiteralZero(prefix)) {
+        return std::nullopt;
+      }
+      prefix_width += prefix->BitCountOrDie();
+    }
+    Node* base = concat->operand(concat->operand_count() - 1);
+    const int64_t base_width = base->BitCountOrDie();
+    if (prefix_width <= 0) {
+      return std::nullopt;
+    }
+    return ZeroExtendedBitsView{.base = base,
+                                .base_width = base_width,
+                                .result_width = result_width,
+                                .leading_zero_width = prefix_width};
+  }
+
+  return std::nullopt;
+}
+
 // Returns true if the given node is a literal with the value one when
 // interpreted as an unsigned number
 inline bool IsLiteralUnsignedOne(Node* node) {
@@ -135,6 +202,29 @@ inline bool AnyTwoOperandsWhere(Node* node,
     if (count >= 2) {
       return true;
     }
+  }
+  return false;
+}
+
+// Returns true if `pred_a` and `pred_b` match `a` and `b` in either order.
+//
+// If a match is found, `on_match(matched_a, matched_b)` is invoked with
+// `matched_a` being the node that satisfied `pred_a` and `matched_b` being the
+// node that satisfied `pred_b`.
+//
+// This is useful for matching commutative patterns while populating additional
+// context via captures in `on_match`.
+inline bool MatchNodesInAnyOrder(
+    Node* a, Node* b, const std::function<bool(Node*)>& pred_a,
+    const std::function<bool(Node*)>& pred_b,
+    const std::function<void(Node*, Node*)>& on_match) {
+  if (pred_a(a) && pred_b(b)) {
+    on_match(a, b);
+    return true;
+  }
+  if (pred_a(b) && pred_b(a)) {
+    on_match(b, a);
+    return true;
   }
   return false;
 }

--- a/xls/ir/node_util.h
+++ b/xls/ir/node_util.h
@@ -48,6 +48,22 @@
 
 namespace xls {
 
+struct ShiftedBitView {
+  Node* b;
+  int64_t k;
+};
+
+// Returns (b, k) if `node` is structurally equivalent to a value with a single
+// potentially-set bit at position `k` (0 == LSb) controlled by the 1-bit value
+// `b`. The recognized forms are:
+//
+// * shll(zext(b), literal(k))
+// * concat(0..., b, 0...)
+//
+// This is a structural matcher and only recognizes literal zeros / literal shift
+// amounts (it does not use any query engine).
+std::optional<ShiftedBitView> IsOneShiftedBit(Node* node);
+
 inline bool IsLiteralZero(Node* node) {
   return node->Is<Literal>() && node->As<Literal>()->value().IsBits() &&
          node->As<Literal>()->value().bits().IsZero();

--- a/xls/jit/BUILD
+++ b/xls/jit/BUILD
@@ -157,7 +157,6 @@ cc_binary(
         "@llvm-project//llvm:ir_headers",
     ],
 )
-
 cc_binary(
     name = "aot_compiler_main",
     srcs = ["aot_compiler_main.cc"],

--- a/xls/jit/aot_compiler_main.cc
+++ b/xls/jit/aot_compiler_main.cc
@@ -46,6 +46,7 @@
 #include "xls/ir/function_base.h"
 #include "xls/ir/ir_parser.h"
 #include "xls/ir/package.h"
+#include "xls/ir/type.h"
 #include "xls/jit/aot_entrypoint.h"
 #include "xls/jit/aot_entrypoint.pb.h"
 #include "xls/jit/block_jit.h"

--- a/xls/jit/orc_jit.cc
+++ b/xls/jit/orc_jit.cc
@@ -49,6 +49,7 @@
 #include "llvm/include/llvm/IR/DataLayout.h"
 #include "llvm/include/llvm/IR/Instruction.h"
 #include "llvm/include/llvm/IR/LegacyPassManager.h"
+#include "llvm/include/llvm/Support/MemoryBuffer.h"
 #include "llvm/include/llvm/IR/Module.h"
 #include "llvm/include/llvm/IRPrinter/IRPrintingPasses.h"
 #include "llvm/include/llvm/Passes/PassBuilder.h"

--- a/xls/passes/range_query_engine.cc
+++ b/xls/passes/range_query_engine.cc
@@ -516,7 +516,23 @@ absl::Status RangeQueryVisitor::HandleDecode(Decode* decode) {
 absl::Status RangeQueryVisitor::HandleDynamicBitSlice(
     DynamicBitSlice* dynamic_bit_slice) {
   INITIALIZE_OR_SKIP(dynamic_bit_slice);
-  return absl::OkStatus();  // TODO(taktoa): implement
+  ASSIGN_INTERVAL_SET_REF_OR_RETURN(to_slice, dynamic_bit_slice->operand(0));
+  ASSIGN_INTERVAL_SET_REF_OR_RETURN(start, dynamic_bit_slice->start());
+  // Many IntervalSet query APIs (e.g. Size/Values/Intervals/ConvexHull) require
+  // the interval set to be normalized. The RangeQueryEngine may hold
+  // non-normalized sets, so normalize local copies here.
+  IntervalSet to_slice_norm = to_slice;
+  if (!to_slice_norm.IsNormalized()) {
+    to_slice_norm.Normalize();
+  }
+  IntervalSet start_norm = start;
+  if (!start_norm.IsNormalized()) {
+    start_norm.Normalize();
+  }
+
+  return SetIntervalSet(dynamic_bit_slice, interval_ops::DynamicBitSlice(
+                                               to_slice_norm, start_norm,
+                                               dynamic_bit_slice->width()));
 }
 
 absl::Status RangeQueryVisitor::HandleDynamicCountedFor(

--- a/xls/passes/range_query_engine_test.cc
+++ b/xls/passes/range_query_engine_test.cc
@@ -864,6 +864,51 @@ FUZZ_TEST(RangeQueryEngineFuzzTest, ConcatIsCorrect)
                  NonemptyNormalizedIntervalSet(5),
                  NonemptyNormalizedIntervalSet(3));
 
+// This is a property test: for all concrete x/start values allowed by the
+// given interval sets, the range analysis result must cover the concrete
+// DynamicBitSlice(x, start, 4) value.
+//
+// We use Covers() (not equality) because RangeQueryEngine is allowed to be
+// conservative; this test is intended to detect unsoundness.
+void DynamicBitSliceIsCorrect(const IntervalSet& x_intervals,
+                              const IntervalSet& start_intervals) {
+  constexpr std::string_view kTestName =
+      "RangeQueryEngineFuzzTest.DynamicBitSliceIsCorrect";
+
+  auto p = std::make_unique<VerifiedPackage>(kTestName);
+  FunctionBuilder fb(kTestName, p.get());
+  BValue x = fb.Param("x", p->GetBitsType(x_intervals.BitCount()));
+  BValue start = fb.Param("start", p->GetBitsType(start_intervals.BitCount()));
+  BValue expr = fb.DynamicBitSlice(x, start, /*width=*/4);
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
+
+  RangeQueryEngine engine;
+  engine.SetIntervalSetTree(x.node(),
+                            BitsLTT(x.node(), x_intervals.Intervals()));
+  engine.SetIntervalSetTree(start.node(),
+                            BitsLTT(start.node(), start_intervals.Intervals()));
+  XLS_ASSERT_OK(engine.Populate(f));
+
+  x_intervals.ForEachElement([&](const Bits& x_bits) -> bool {
+    start_intervals.ForEachElement([&](const Bits& start_bits) -> bool {
+      const int64_t shift_amount =
+          bits_ops::UnsignedBitsToSaturatedInt64(start_bits);
+      Bits out(4);
+      if (shift_amount < x_bits.bit_count()) {
+        out = bits_ops::ShiftRightLogical(x_bits, shift_amount)
+                  .Slice(0, /*width=*/4);
+      }
+      EXPECT_TRUE(engine.GetIntervalSetTree(expr.node()).Get({}).Covers(out));
+      return false;
+    });
+    return false;
+  });
+}
+
+FUZZ_TEST(RangeQueryEngineFuzzTest, DynamicBitSliceIsCorrect)
+    .WithDomains(NonemptyNormalizedIntervalSet(6),
+                 NonemptyNormalizedIntervalSet(3));
+
 TEST_F(RangeQueryEngineTest, Decode) {
   auto p = CreatePackage();
   FunctionBuilder fb(TestName(), p.get());
@@ -917,6 +962,116 @@ TEST_F(RangeQueryEngineTest, DecodePreciseOverflow) {
       x.node(), BitsLTT(x.node(), {Interval::Precise(UBits(13, 4))}));
   XLS_ASSERT_OK(engine.Populate(f));
   EXPECT_EQ("0b00_0000_0000", engine.ToString(expr.node()));
+}
+
+TEST_F(RangeQueryEngineTest, DynamicBitSlicePreciseStart) {
+  auto p = CreatePackage();
+  FunctionBuilder fb(TestName(), p.get());
+
+  BValue x = fb.Param("x", p->GetBitsType(8));
+  BValue start = fb.Literal(UBits(2, 3));
+  BValue expr = fb.DynamicBitSlice(x, start, /*width=*/4);
+
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
+
+  IntervalSet x_intervals =
+      IntervalSet::Of({Interval(UBits(10, 8), UBits(200, 8))});
+  RangeQueryEngine engine;
+  engine.SetIntervalSetTree(x.node(),
+                            BitsLTT(x.node(), x_intervals.Intervals()));
+  XLS_ASSERT_OK(engine.Populate(f));
+
+  IntervalSet expected =
+      interval_ops::BitSlice(x_intervals, /*start=*/2, /*width=*/4);
+  IntervalSet got = engine.GetIntervals(expr.node()).Get({});
+  EXPECT_EQ(got, expected);
+}
+
+TEST_F(RangeQueryEngineTest, DynamicBitSliceSmallStartSet) {
+  auto p = CreatePackage();
+  FunctionBuilder fb(TestName(), p.get());
+
+  BValue x = fb.Param("x", p->GetBitsType(8));
+  BValue start = fb.Param("start", p->GetBitsType(4));
+  BValue expr = fb.DynamicBitSlice(x, start, /*width=*/4);
+
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
+
+  IntervalSet x_intervals =
+      IntervalSet::Of({Interval(UBits(10, 8), UBits(200, 8))});
+  IntervalSet start_intervals = IntervalSet::Of(
+      {Interval::Precise(UBits(0, 4)), Interval::Precise(UBits(2, 4)),
+       Interval::Precise(UBits(7, 4)), Interval::Precise(UBits(8, 4))});
+  start_intervals.Normalize();
+
+  IntervalSet expected(4);
+  expected.Normalize();
+  expected =
+      IntervalSet::Combine(expected, interval_ops::BitSlice(x_intervals, 0, 4));
+  expected =
+      IntervalSet::Combine(expected, interval_ops::BitSlice(x_intervals, 2, 4));
+  expected =
+      IntervalSet::Combine(expected, interval_ops::BitSlice(x_intervals, 7, 4));
+  expected.AddInterval(Interval::Precise(UBits(0, 4)));
+  expected.Normalize();
+
+  RangeQueryEngine engine;
+  engine.SetIntervalSetTree(x.node(),
+                            BitsLTT(x.node(), x_intervals.Intervals()));
+  engine.SetIntervalSetTree(start.node(),
+                            BitsLTT(start.node(), start_intervals.Intervals()));
+  XLS_ASSERT_OK(engine.Populate(f));
+
+  IntervalSet got = engine.GetIntervals(expr.node()).Get({});
+  EXPECT_EQ(got, expected);
+}
+
+TEST_F(RangeQueryEngineTest, DynamicBitSliceAlwaysOvershiftIsZero) {
+  auto p = CreatePackage();
+  FunctionBuilder fb(TestName(), p.get());
+
+  BValue x = fb.Param("x", p->GetBitsType(8));
+  BValue start = fb.Param("start", p->GetBitsType(4));
+  BValue expr = fb.DynamicBitSlice(x, start, /*width=*/4);
+
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
+
+  IntervalSet x_intervals =
+      IntervalSet::Of({Interval(UBits(10, 8), UBits(200, 8))});
+  IntervalSet start_intervals =
+      IntervalSet::Of({Interval(UBits(8, 4), UBits(15, 4))});
+  start_intervals.Normalize();
+
+  RangeQueryEngine engine;
+  engine.SetIntervalSetTree(x.node(),
+                            BitsLTT(x.node(), x_intervals.Intervals()));
+  engine.SetIntervalSetTree(start.node(),
+                            BitsLTT(start.node(), start_intervals.Intervals()));
+  XLS_ASSERT_OK(engine.Populate(f));
+
+  IntervalSet got = engine.GetIntervals(expr.node()).Get({});
+  EXPECT_EQ(got, IntervalSet::Precise(UBits(0, 4)));
+}
+
+TEST_F(RangeQueryEngineTest, DynamicBitSliceLargeStartFallsBackToMaximal) {
+  auto p = CreatePackage();
+  FunctionBuilder fb(TestName(), p.get());
+
+  BValue x = fb.Param("x", p->GetBitsType(8));
+  BValue start = fb.Param("start", p->GetBitsType(16));
+  BValue expr = fb.DynamicBitSlice(x, start, /*width=*/4);
+
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
+
+  IntervalSet x_intervals =
+      IntervalSet::Of({Interval(UBits(10, 8), UBits(200, 8))});
+  RangeQueryEngine engine;
+  engine.SetIntervalSetTree(x.node(),
+                            BitsLTT(x.node(), x_intervals.Intervals()));
+  XLS_ASSERT_OK(engine.Populate(f));
+
+  IntervalSet got = engine.GetIntervals(expr.node()).Get({});
+  EXPECT_TRUE(got.IsMaximal());
 }
 
 TEST_F(RangeQueryEngineTest, DecodeUnconstrained) {

--- a/xls/public/c_api.cc
+++ b/xls/public/c_api.cc
@@ -1545,11 +1545,11 @@ void xls_aot_exec_context_free(struct xls_aot_exec_context* context) {
 }
 
 int64_t xls_aot_entrypoint_trampoline(
-    void* function_ptr, const uint8_t* const* inputs, uint8_t* const* outputs,
-    void* temp_buffer, struct xls_aot_exec_context* context,
-    int64_t continuation_point, size_t* trace_messages_count_out,
-    size_t* assert_messages_count_out) {
-  CHECK_NE(function_ptr, nullptr);
+    uintptr_t function_ptr, const uint8_t* const* inputs,
+    uint8_t* const* outputs, void* temp_buffer,
+    struct xls_aot_exec_context* context, int64_t continuation_point,
+    size_t* trace_messages_count_out, size_t* assert_messages_count_out) {
+  CHECK_NE(function_ptr, 0);
   CHECK_NE(inputs, nullptr);
   CHECK_NE(outputs, nullptr);
   CHECK_NE(context, nullptr);

--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -570,10 +570,10 @@ void xls_aot_exec_context_free(struct xls_aot_exec_context* context);
 // `function_ptr` must be the symbol address of an AOT entrypoint compatible
 // with the `JitFunctionType` ABI.
 int64_t xls_aot_entrypoint_trampoline(
-    void* function_ptr, const uint8_t* const* inputs, uint8_t* const* outputs,
-    void* temp_buffer, struct xls_aot_exec_context* context,
-    int64_t continuation_point, size_t* trace_messages_count_out,
-    size_t* assert_messages_count_out);
+    uintptr_t function_ptr, const uint8_t* const* inputs,
+    uint8_t* const* outputs, void* temp_buffer,
+    struct xls_aot_exec_context* context, int64_t continuation_point,
+    size_t* trace_messages_count_out, size_t* assert_messages_count_out);
 
 struct xls_trace_message {
   char* message;

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -26,12 +26,12 @@
 #include <variant>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/base/macros.h"
 #include "absl/cleanup/cleanup.h"
 #include "absl/log/log.h"
 #include "absl/strings/str_format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "llvm/include/llvm/ExecutionEngine/Orc/ExecutionUtils.h"
 #include "llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/include/llvm/Support/Error.h"
@@ -2301,8 +2301,9 @@ top fn add_one(x: bits[8]) -> bits[8] {
   size_t trace_messages_count = 0;
   size_t assert_messages_count = 0;
   int64_t continuation = xls_aot_entrypoint_trampoline(
-      packed_address.toPtr<void*>(), inputs, outputs, temp_buffer, context,
-      /*continuation_point=*/0, &trace_messages_count, &assert_messages_count);
+      static_cast<uintptr_t>(packed_address.getValue()), inputs, outputs,
+      temp_buffer, context, /*continuation_point=*/0, &trace_messages_count,
+      &assert_messages_count);
 
   EXPECT_EQ(continuation, 0);
   EXPECT_EQ(output, 42);


### PR DESCRIPTION
These platforms:

- Rocky8 linux
- Ubuntu 20.04
- Ubuntu 24.04
- macos arm64
  -  I performed an ablation on these changes to be certain they're required
 
I tested that "plain old bazel build" works for all of these:

  - //xls/dev_tools:check_ir_equivalence_main
  - //xls/dslx:interpreter_main
  - //xls/dslx/lsp:dslx_ls
  - //xls/tools:opt_main
  - //xls/tools:codegen_main
  - //xls/dslx/ir_convert:ir_converter_main
  - //xls/tools:delay_info_main
  - //xls/dslx:dslx_fmt
  - //xls/dslx:prove_quickcheck_main
  - //xls/dslx/type_system:typecheck_main
  - //xls/tools:block_to_verilog_main

  LINUX_TARGETS is that list plus //xls/public:libxls.so, and MACOS_TARGETS is that list plus //xls/public:libxls.dylib.
 
 I also ensured that make_local_release.py keeps working too. 

 ---
The most obvious difference for macos is try building this `bazel build //xls/tools:delay_info_main` with and without this PR. Note that without this PR, you should still uncomment the LLVM block, IIRC.