### PR TITLE
xlsynth: publish Linux libxls runtime-closure assets

### DIFF
--- a/.github/workflows/build-and-release-dylib.yml
+++ b/.github/workflows/build-and-release-dylib.yml
@@ -183,6 +183,9 @@ jobs:
         gzip -c bazel-bin/xls/public/libxls.so > rocky8-artifacts/libxls-rocky8.so.gz
         sha256sum rocky8-artifacts/libxls-rocky8.so.gz > rocky8-artifacts/libxls-rocky8.so.gz.sha256
         sha256sum bazel-bin/xls/public/libxls.so > rocky8-artifacts/libxls-rocky8.so.sha256
+        python3 dist/package_runtime_closure.py --libxls bazel-bin/xls/public/libxls.so --output-dir rocky8-artifacts --platform rocky8
+        sha256sum rocky8-artifacts/libxls-runtime-rocky8.tar.gz > rocky8-artifacts/libxls-runtime-rocky8.tar.gz.sha256
+        sha256sum rocky8-artifacts/libxls-runtime-rocky8-manifest.json > rocky8-artifacts/libxls-runtime-rocky8-manifest.json.sha256
 
         cp bazel-bin/xls/dslx/interpreter_main              rocky8-artifacts/dslx_interpreter_main-rocky8
         sha256sum rocky8-artifacts/dslx_interpreter_main-rocky8 > rocky8-artifacts/dslx_interpreter_main-rocky8.sha256
@@ -336,6 +339,9 @@ jobs:
         gzip -c bazel-bin/xls/public/libxls.so > ubuntu2004-artifacts/libxls-ubuntu2004.so.gz
         sha256sum ubuntu2004-artifacts/libxls-ubuntu2004.so.gz > ubuntu2004-artifacts/libxls-ubuntu2004.so.gz.sha256
         sha256sum bazel-bin/xls/public/libxls.so > ubuntu2004-artifacts/libxls-ubuntu2004.so.sha256
+        python3 dist/package_runtime_closure.py --libxls bazel-bin/xls/public/libxls.so --output-dir ubuntu2004-artifacts --platform ubuntu2004
+        sha256sum ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz > ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz.sha256
+        sha256sum ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json > ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json.sha256
 
         cp bazel-bin/xls/dslx/interpreter_main             ubuntu2004-artifacts/dslx_interpreter_main-ubuntu2004
         sha256sum ubuntu2004-artifacts/dslx_interpreter_main-ubuntu2004 > ubuntu2004-artifacts/dslx_interpreter_main-ubuntu2004.sha256
@@ -464,6 +470,10 @@ jobs:
           ubuntu2004-artifacts/libxls-ubuntu2004.so.gz \
           ubuntu2004-artifacts/libxls-ubuntu2004.so.gz.sha256 \
           ubuntu2004-artifacts/libxls-ubuntu2004.so.sha256 \
+          ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz \
+          ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz.sha256 \
+          ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json \
+          ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json.sha256 \
           ubuntu2004-artifacts/dslx_interpreter_main-ubuntu2004 \
           ubuntu2004-artifacts/dslx_interpreter_main-ubuntu2004.sha256 \
           ubuntu2004-artifacts/dslx_ls-ubuntu2004 \
@@ -491,6 +501,10 @@ jobs:
           rocky8-artifacts/libxls-rocky8.so.gz \
           rocky8-artifacts/libxls-rocky8.so.gz.sha256 \
           rocky8-artifacts/libxls-rocky8.so.sha256 \
+          rocky8-artifacts/libxls-runtime-rocky8.tar.gz \
+          rocky8-artifacts/libxls-runtime-rocky8.tar.gz.sha256 \
+          rocky8-artifacts/libxls-runtime-rocky8-manifest.json \
+          rocky8-artifacts/libxls-runtime-rocky8-manifest.json.sha256 \
           rocky8-artifacts/dslx_interpreter_main-rocky8 \
           rocky8-artifacts/dslx_interpreter_main-rocky8.sha256 \
           rocky8-artifacts/dslx_ls-rocky8 \

--- a/.github/workflows/build-and-release-dylib.yml
+++ b/.github/workflows/build-and-release-dylib.yml
@@ -183,7 +183,7 @@ jobs:
         gzip -c bazel-bin/xls/public/libxls.so > rocky8-artifacts/libxls-rocky8.so.gz
         sha256sum rocky8-artifacts/libxls-rocky8.so.gz > rocky8-artifacts/libxls-rocky8.so.gz.sha256
         sha256sum bazel-bin/xls/public/libxls.so > rocky8-artifacts/libxls-rocky8.so.sha256
-        python3 dist/package_runtime_closure.py --libxls bazel-bin/xls/public/libxls.so --output-dir rocky8-artifacts --platform rocky8
+        python3 dist/package_runtime_closure.py --libxls bazel-bin/xls/public/libxls.so --output-dir rocky8-artifacts --release-target rocky8
         sha256sum rocky8-artifacts/libxls-runtime-rocky8.tar.gz > rocky8-artifacts/libxls-runtime-rocky8.tar.gz.sha256
         sha256sum rocky8-artifacts/libxls-runtime-rocky8-manifest.json > rocky8-artifacts/libxls-runtime-rocky8-manifest.json.sha256
 
@@ -339,7 +339,7 @@ jobs:
         gzip -c bazel-bin/xls/public/libxls.so > ubuntu2004-artifacts/libxls-ubuntu2004.so.gz
         sha256sum ubuntu2004-artifacts/libxls-ubuntu2004.so.gz > ubuntu2004-artifacts/libxls-ubuntu2004.so.gz.sha256
         sha256sum bazel-bin/xls/public/libxls.so > ubuntu2004-artifacts/libxls-ubuntu2004.so.sha256
-        python3 dist/package_runtime_closure.py --libxls bazel-bin/xls/public/libxls.so --output-dir ubuntu2004-artifacts --platform ubuntu2004
+        python3 dist/package_runtime_closure.py --libxls bazel-bin/xls/public/libxls.so --output-dir ubuntu2004-artifacts --release-target ubuntu2004
         sha256sum ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz > ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz.sha256
         sha256sum ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json > ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json.sha256
 

--- a/dist/package_runtime_closure.py
+++ b/dist/package_runtime_closure.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+"""CLI wrapper for packaging non-system Linux DSOs needed to load libxls."""
+
+import argparse
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import release_runtime_closure
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--libxls", required = True)
+    parser.add_argument("--output-dir", required = True)
+    parser.add_argument("--platform", default = "")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    libxls_path = Path(args.libxls)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents = True, exist_ok = True)
+    platform = args.platform or release_runtime_closure.detect_linux_release_platform()
+    result = release_runtime_closure.package_runtime_closure(libxls_path, output_dir, platform)
+    print("Wrote {}".format(result["archive_path"]))
+    print("Wrote {}".format(result["manifest_path"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/dist/package_runtime_closure.py
+++ b/dist/package_runtime_closure.py
@@ -2,7 +2,6 @@
 
 """CLI wrapper for packaging non-system Linux DSOs needed to load libxls."""
 
-import argparse
 from pathlib import Path
 import sys
 
@@ -11,21 +10,20 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import release_runtime_closure
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--libxls", required = True)
-    parser.add_argument("--output-dir", required = True)
-    parser.add_argument("--platform", default = "")
-    return parser.parse_args()
-
-
 def main() -> None:
-    args = parse_args()
+    args = release_runtime_closure.parse_args(sys.argv[1:])
     libxls_path = Path(args.libxls)
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents = True, exist_ok = True)
-    platform = args.platform or release_runtime_closure.detect_linux_release_platform()
-    result = release_runtime_closure.package_runtime_closure(libxls_path, output_dir, platform)
+    release_target = release_runtime_closure.validate_linux_release_target(
+        args.release_target
+    )
+    result = release_runtime_closure.package_runtime_closure(
+        libxls_path,
+        output_dir,
+        release_target,
+        allow_release_target_mismatch = args.allow_release_target_mismatch,
+    )
     print("Wrote {}".format(result["archive_path"]))
     print("Wrote {}".format(result["manifest_path"]))
 

--- a/make_local_release.py
+++ b/make_local_release.py
@@ -56,6 +56,17 @@ IMPORT_RE = re.compile(r'^\s*import\s+"([^"]+)";\s*$')
 AOT_ENTRYPOINT_PROTO = "xls/jit/aot_entrypoint.proto"
 
 
+def resolve_release_target(requested_release_target):
+    if not requested_release_target:
+        raise ValueError(
+            "Local releases require --release-target (supported values: {})".format(
+                ", ".join(release_runtime_closure.SUPPORTED_RELEASE_TARGETS),
+            )
+        )
+    else:
+        return release_runtime_closure.parse_release_target(requested_release_target)
+
+
 def collect_proto_dependencies(proto_path):
     """Returns all local proto dependencies reachable from `proto_path`."""
     all_protos = set()
@@ -118,7 +129,14 @@ def get_git_info():
 
 # Main function to handle the release process.
 # Now accepts an optional `mode` argument to change the Bazel command.
-def make_local_release(output_dir, targets, run_tests=True, mode="opt"):
+def make_local_release(
+    output_dir,
+    targets,
+    run_tests=True,
+    mode="opt",
+    release_target=None,
+    allow_release_target_mismatch=False,
+):
     # Ensure the output directory exists and is writable
     if os.path.exists(output_dir):
         try:
@@ -207,15 +225,25 @@ def make_local_release(output_dir, targets, run_tests=True, mode="opt"):
 
     if "//xls/public:libxls.so" in targets:
         primary_dso_path = os.path.join(output_dir, "libxls.so")
-        platform = release_runtime_closure.detect_linux_release_platform()
-        release_named_dso_path = os.path.join(output_dir, f"libxls-{platform}.so")
+        if release_target is None:
+            print("Linux local releases require a Linux --release-target")
+            sys.exit(1)
+        release_target = release_runtime_closure.validate_matching_linux_release_target(
+            release_target,
+            allow_release_target_mismatch = allow_release_target_mismatch,
+        )
+        release_named_dso_path = os.path.join(
+            output_dir,
+            f"libxls-{release_target.artifact_suffix}.so",
+        )
         try:
             shutil.copy2(primary_dso_path, release_named_dso_path)
             print(f"Copied {primary_dso_path} to {release_named_dso_path}")
             packaged_runtime = release_runtime_closure.package_runtime_closure(
                 primary_dso_path = primary_dso_path,
                 output_dir = output_dir,
-                platform = platform,
+                release_target = release_target,
+                allow_release_target_mismatch = allow_release_target_mismatch,
             )
             print(
                 "Packaged Linux runtime closure: {} and {}".format(
@@ -281,21 +309,48 @@ def make_local_release(output_dir, targets, run_tests=True, mode="opt"):
         print(f"Failed to generate diff against main: {e}")
 
 # New main() function using optparse
-def main():
+def parse_cli_args(argv):
     from optparse import OptionParser
 
     usage = "usage: %prog [options] output_directory"
     parser = OptionParser(usage=usage)
     parser.add_option("-m", "--mode", dest="mode", default="opt", choices=["opt", "dbg-asan", "dbg"],
                       help="Build mode: opt (default) or dbg-asan")
-    parser.add_option("--macos", action="store_true", default=False, help="Build for macOS")
-    options, args = parser.parse_args()
+    parser.add_option(
+        "--release-target",
+        dest="release_target",
+        help="Release target profile name",
+    )
+    parser.add_option(
+        "--allow-release-target-mismatch",
+        dest="allow_release_target_mismatch",
+        action="store_true",
+        default=False,
+        help="Allow Linux artifact naming that differs from the detected host release target",
+    )
+    options, args = parser.parse_args(argv)
 
     if len(args) != 1:
         parser.error("You must specify exactly one output directory")
-    output_dir = args[0]
+    try:
+        release_target = resolve_release_target(options.release_target)
+    except ValueError as e:
+        parser.error(str(e))
+    options.release_target = release_target
+    if (
+        options.allow_release_target_mismatch
+        and release_target == release_runtime_closure.ReleaseTarget.MACOS_ARM64
+    ):
+        parser.error("--allow-release-target-mismatch only applies to Linux release targets")
+    return options, args[0]
 
-    if options.macos:
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+    options, output_dir = parse_cli_args(argv)
+
+    if options.release_target == release_runtime_closure.ReleaseTarget.MACOS_ARM64:
         # Tests do not work on MacOS because static initializers of the estimators are
         # stripped out which breaks the build.
         make_local_release(
@@ -310,6 +365,8 @@ def main():
             LINUX_TARGETS,
             run_tests=True,
             mode=options.mode,
+            release_target=options.release_target,
+            allow_release_target_mismatch=options.allow_release_target_mismatch,
         )
 
 if __name__ == "__main__":

--- a/make_local_release.py
+++ b/make_local_release.py
@@ -19,6 +19,8 @@ import sys
 import glob
 import re
 
+import release_runtime_closure
+
 # List of Bazel targets to build
 COMMON_TARGETS = [
     "//xls/dev_tools:check_ir_equivalence_main",
@@ -201,6 +203,28 @@ def make_local_release(output_dir, targets, run_tests=True, mode="opt"):
             print(f"Copied {binary_path} to {destination_path}")
         except PermissionError as e:
             print(f"Permission denied while copying {binary_path}: {e}")
+            sys.exit(1)
+
+    if "//xls/public:libxls.so" in targets:
+        primary_dso_path = os.path.join(output_dir, "libxls.so")
+        platform = release_runtime_closure.detect_linux_release_platform()
+        release_named_dso_path = os.path.join(output_dir, f"libxls-{platform}.so")
+        try:
+            shutil.copy2(primary_dso_path, release_named_dso_path)
+            print(f"Copied {primary_dso_path} to {release_named_dso_path}")
+            packaged_runtime = release_runtime_closure.package_runtime_closure(
+                primary_dso_path = primary_dso_path,
+                output_dir = output_dir,
+                platform = platform,
+            )
+            print(
+                "Packaged Linux runtime closure: {} and {}".format(
+                    packaged_runtime["archive_path"],
+                    packaged_runtime["manifest_path"],
+                )
+            )
+        except (OSError, RuntimeError) as e:
+            print(f"Failed to package Linux runtime closure: {e}")
             sys.exit(1)
 
     # Copy the standard library files to the output directory in the same relpath locations

--- a/make_local_release_test.py
+++ b/make_local_release_test.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import make_local_release
+
+
+class MakeLocalReleaseTest(unittest.TestCase):
+    def test_parse_cli_args_accepts_release_target(self):
+        options, output_dir = make_local_release.parse_cli_args(
+            ["--release-target", "ubuntu2004", "/tmp/output"]
+        )
+
+        self.assertEqual(options.release_target.cli_name, "ubuntu2004")
+        self.assertEqual(output_dir, "/tmp/output")
+
+    def test_parse_cli_args_accepts_macos_release_target(self):
+        options, _ = make_local_release.parse_cli_args(
+            ["--release-target", "macos-arm64", "/tmp/output"]
+        )
+
+        self.assertEqual(options.release_target.cli_name, "macos-arm64")
+
+    def test_parse_cli_args_rejects_legacy_macos_flag(self):
+        with self.assertRaises(SystemExit):
+            make_local_release.parse_cli_args(["--macos", "/tmp/output"])
+
+    def test_parse_cli_args_rejects_unknown_release_target(self):
+        with self.assertRaises(SystemExit):
+            make_local_release.parse_cli_args(
+                ["--release-target", "ubuntu2404", "/tmp/output"]
+            )
+
+    def test_parse_cli_args_accepts_release_target_mismatch_override(self):
+        options, _ = make_local_release.parse_cli_args(
+            [
+                "--release-target",
+                "ubuntu2004",
+                "--allow-release-target-mismatch",
+                "/tmp/output",
+            ]
+        )
+
+        self.assertTrue(options.allow_release_target_mismatch)
+
+    def test_parse_cli_args_rejects_release_target_mismatch_override_for_macos(self):
+        with self.assertRaises(SystemExit):
+            make_local_release.parse_cli_args(
+                [
+                    "--release-target",
+                    "macos-arm64",
+                    "--allow-release-target-mismatch",
+                    "/tmp/output",
+                ]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/release_runtime_closure.py
+++ b/release_runtime_closure.py
@@ -17,6 +17,7 @@
 """Packages the non-system Linux runtime closure for a released libxls shared library."""
 
 import argparse
+from enum import Enum
 import gzip
 import io
 import json
@@ -33,21 +34,137 @@ _SYSTEM_LIBRARY_PREFIXES = (
 )
 
 
-def build_runtime_archive_filename(platform):
-    return f"libxls-runtime-{platform}.tar.gz"
+class ReleaseTarget(Enum):
+    MACOS_ARM64 = ("macos-arm64", "arm64", None)
+    ROCKY8 = ("rocky8", "rocky8", "rocky8")
+    UBUNTU2004 = ("ubuntu2004", "ubuntu2004", "ubuntu2004")
+
+    def __init__(self, cli_name, artifact_suffix, runtime_platform):
+        self.cli_name = cli_name
+        self.artifact_suffix = artifact_suffix
+        self.runtime_platform = runtime_platform
+
+    @property
+    def is_linux(self):
+        return self.runtime_platform is not None
 
 
-def build_runtime_manifest_filename(platform):
-    return f"libxls-runtime-{platform}-manifest.json"
+RELEASE_TARGETS_BY_NAME = {
+    release_target.cli_name: release_target for release_target in ReleaseTarget
+}
+SUPPORTED_RELEASE_TARGETS = tuple(
+    release_target.cli_name for release_target in ReleaseTarget
+)
+SUPPORTED_LINUX_RELEASE_TARGETS = tuple(
+    release_target.cli_name
+    for release_target in ReleaseTarget
+    if release_target.is_linux
+)
+
+
+def parse_release_target(release_target_name):
+    release_target = RELEASE_TARGETS_BY_NAME.get(release_target_name)
+    if release_target is None:
+        raise ValueError(
+            "Unsupported release target {}. Expected one of: {}".format(
+                release_target_name,
+                ", ".join(SUPPORTED_RELEASE_TARGETS),
+            )
+        )
+    else:
+        return release_target
+
+
+def validate_linux_release_target(release_target_name):
+    release_target = parse_release_target(release_target_name)
+    if release_target.is_linux:
+        return release_target
+    else:
+        raise ValueError(
+            "Release target {} does not package a Linux runtime closure. Expected one of: {}".format(
+                release_target.cli_name,
+                ", ".join(SUPPORTED_LINUX_RELEASE_TARGETS),
+            )
+        )
+
+
+def coerce_linux_release_target(release_target):
+    if isinstance(release_target, ReleaseTarget):
+        if release_target.is_linux:
+            return release_target
+        else:
+            raise ValueError(
+                "Release target {} does not package a Linux runtime closure. Expected one of: {}".format(
+                    release_target.cli_name,
+                    ", ".join(SUPPORTED_LINUX_RELEASE_TARGETS),
+                )
+            )
+    else:
+        return validate_linux_release_target(release_target)
+
+
+def build_runtime_archive_filename(release_target):
+    linux_release_target = coerce_linux_release_target(release_target)
+    return f"libxls-runtime-{linux_release_target.artifact_suffix}.tar.gz"
+
+
+def build_runtime_manifest_filename(release_target):
+    linux_release_target = coerce_linux_release_target(release_target)
+    return f"libxls-runtime-{linux_release_target.artifact_suffix}-manifest.json"
+
+
+def detect_linux_release_target(os_release_path = Path("/etc/os-release")):
+    if not os_release_path.exists():
+        raise RuntimeError(
+            "Cannot detect Linux release target from missing {}".format(os_release_path)
+        )
+    release_fields = {}
+    for raw_line in os_release_path.read_text(encoding = "utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        release_fields[key] = value.strip().strip('"').strip("'").lower()
+    release_id = release_fields.get("ID", "")
+    version_id = release_fields.get("VERSION_ID", "")
+    if release_id == "ubuntu" and version_id == "20.04":
+        return ReleaseTarget.UBUNTU2004
+    elif release_id in {"rocky", "rhel", "almalinux", "centos"} and version_id.startswith("8"):
+        return ReleaseTarget.ROCKY8
+    else:
+        raise RuntimeError(
+            "Unsupported Linux release for auto-detected packaging: ID={} VERSION_ID={}".format(
+                release_id or "<missing>",
+                version_id or "<missing>",
+            )
+        )
 
 
 def detect_linux_release_platform(os_release_path = Path("/etc/os-release")):
-    if not os_release_path.exists():
-        return "ubuntu2004"
-    contents = os_release_path.read_text(encoding = "utf-8").lower()
-    if any(marker in contents for marker in ["rocky", "rhel", "almalinux", "centos"]):
-        return "rocky8"
-    return "ubuntu2004"
+    return detect_linux_release_target(os_release_path).runtime_platform
+
+
+def validate_matching_linux_release_target(
+    release_target,
+    allow_release_target_mismatch = False,
+    os_release_path = Path("/etc/os-release"),
+):
+    linux_release_target = coerce_linux_release_target(release_target)
+    detected_release_target = detect_linux_release_target(os_release_path)
+    if (
+        allow_release_target_mismatch
+        or detected_release_target == linux_release_target
+    ):
+        return linux_release_target
+    else:
+        raise RuntimeError(
+            "Requested Linux release target {} does not match detected host {} from {}. "
+            "Re-run with --allow-release-target-mismatch only if you intentionally need cross-target naming.".format(
+                linux_release_target.cli_name,
+                detected_release_target.cli_name,
+                os_release_path,
+            )
+        )
 
 
 def run_text_command(args):
@@ -172,16 +289,27 @@ def write_runtime_manifest(manifest_path, manifest):
     )
 
 
-def package_runtime_closure(primary_dso_path, output_dir, platform):
+def package_runtime_closure(
+    primary_dso_path,
+    output_dir,
+    release_target,
+    allow_release_target_mismatch = False,
+    os_release_path = Path("/etc/os-release"),
+):
     primary_path = Path(primary_dso_path)
     target_dir = Path(output_dir)
     target_dir.mkdir(parents = True, exist_ok = True)
+    linux_release_target = validate_matching_linux_release_target(
+        release_target,
+        allow_release_target_mismatch = allow_release_target_mismatch,
+        os_release_path = os_release_path,
+    )
 
     runtime_files = collect_runtime_closure(primary_path)
     manifest = build_runtime_manifest(primary_path.name, runtime_files)
 
-    archive_path = target_dir / build_runtime_archive_filename(platform)
-    manifest_path = target_dir / build_runtime_manifest_filename(platform)
+    archive_path = target_dir / build_runtime_archive_filename(linux_release_target)
+    manifest_path = target_dir / build_runtime_manifest_filename(linux_release_target)
 
     create_runtime_archive(archive_path, runtime_files)
     write_runtime_manifest(manifest_path, manifest)
@@ -196,16 +324,23 @@ def parse_args(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("--libxls", required = True)
     parser.add_argument("--output-dir", required = True)
-    parser.add_argument("--platform", required = True)
+    parser.add_argument("--release-target", required = True)
+    parser.add_argument(
+        "--allow-release-target-mismatch",
+        action = "store_true",
+        help = "allow Linux artifact naming that does not match the detected host release target",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv):
     args = parse_args(argv)
+    release_target = validate_linux_release_target(args.release_target)
     result = package_runtime_closure(
         primary_dso_path = args.libxls,
         output_dir = args.output_dir,
-        platform = args.platform,
+        release_target = release_target,
+        allow_release_target_mismatch = args.allow_release_target_mismatch,
     )
     print("Packaged runtime closure:")
     print("  archive: {}".format(result["archive_path"]))

--- a/release_runtime_closure.py
+++ b/release_runtime_closure.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Packages the non-system Linux runtime closure for a released libxls shared library."""
+
+import argparse
+import gzip
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import tarfile
+
+_SYSTEM_LIBRARY_PREFIXES = (
+    "/lib/",
+    "/lib64/",
+    "/usr/lib64/",
+    "/usr/lib/x86_64-linux-gnu/",
+)
+
+
+def build_runtime_archive_filename(platform):
+    return f"libxls-runtime-{platform}.tar.gz"
+
+
+def build_runtime_manifest_filename(platform):
+    return f"libxls-runtime-{platform}-manifest.json"
+
+
+def detect_linux_release_platform(os_release_path = Path("/etc/os-release")):
+    if not os_release_path.exists():
+        return "ubuntu2004"
+    contents = os_release_path.read_text(encoding = "utf-8").lower()
+    if any(marker in contents for marker in ["rocky", "rhel", "almalinux", "centos"]):
+        return "rocky8"
+    return "ubuntu2004"
+
+
+def run_text_command(args):
+    return subprocess.run(
+        args,
+        check = False,
+        capture_output = True,
+        text = True,
+    )
+
+
+def parse_ldd_output(stdout, subject_path):
+    resolved = {}
+    missing = []
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line or "=>" not in line:
+            continue
+        name, remainder = [piece.strip() for piece in line.split("=>", 1)]
+        target = remainder.split("(", 1)[0].strip()
+        if target == "not found":
+            missing.append(name)
+        elif target:
+            resolved[name] = Path(target)
+    if missing:
+        raise RuntimeError(
+            "Missing runtime dependencies for {}: {}".format(
+                subject_path,
+                ", ".join(sorted(missing)),
+            )
+        )
+    return resolved
+
+
+def resolve_direct_dependencies(shared_library_path):
+    result = run_text_command(["ldd", str(shared_library_path)])
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Failed to inspect dynamic dependencies for {}\nstdout:\n{}\nstderr:\n{}".format(
+                shared_library_path,
+                result.stdout,
+                result.stderr,
+            )
+        )
+    return parse_ldd_output(result.stdout, shared_library_path)
+
+
+def should_bundle_runtime_dependency(dependency_path):
+    normalized_path = os.path.realpath(str(dependency_path))
+    return not any(
+        normalized_path == prefix[:-1] or normalized_path.startswith(prefix)
+        for prefix in _SYSTEM_LIBRARY_PREFIXES
+    )
+
+
+def collect_runtime_closure(primary_dso_path, dependency_resolver = resolve_direct_dependencies):
+    primary_path = Path(primary_dso_path)
+    pending = [primary_path]
+    bundled = {}
+    visited = set()
+
+    while pending:
+        current = pending.pop()
+        current_key = str(current.resolve())
+        if current_key in visited:
+            continue
+        visited.add(current_key)
+
+        for dependency_name, dependency_path in dependency_resolver(current).items():
+            if not should_bundle_runtime_dependency(dependency_path):
+                continue
+            bundled_path = bundled.get(dependency_name)
+            if bundled_path is not None:
+                if bundled_path.resolve() != dependency_path.resolve():
+                    raise RuntimeError(
+                        "Dependency {} resolved to two different paths: {} and {}".format(
+                            dependency_name,
+                            bundled_path,
+                            dependency_path,
+                        )
+                    )
+                continue
+            bundled[dependency_name] = dependency_path
+            pending.append(dependency_path)
+
+    return [bundled[name] for name in sorted(bundled)]
+
+
+def build_runtime_manifest(primary_dso_name, runtime_files):
+    return {
+        "primary_dso": primary_dso_name,
+        "runtime_files": [path.name for path in runtime_files],
+    }
+
+
+def add_file_to_archive(archive, source_path):
+    resolved_path = source_path.resolve()
+    tar_info = tarfile.TarInfo(name = source_path.name)
+    tar_info.mode = 0o644
+    tar_info.mtime = 0
+    tar_info.uid = 0
+    tar_info.gid = 0
+    tar_info.uname = ""
+    tar_info.gname = ""
+    file_bytes = resolved_path.read_bytes()
+    tar_info.size = len(file_bytes)
+    archive.addfile(tar_info, io.BytesIO(file_bytes))
+
+
+def create_runtime_archive(archive_path, runtime_files):
+    with open(archive_path, "wb") as raw_file:
+        with gzip.GzipFile(filename = "", mode = "wb", fileobj = raw_file, mtime = 0) as gzip_file:
+            with tarfile.open(fileobj = gzip_file, mode = "w", format = tarfile.PAX_FORMAT) as archive:
+                for runtime_file in sorted(runtime_files, key = lambda path: path.name):
+                    add_file_to_archive(archive, runtime_file)
+
+
+def write_runtime_manifest(manifest_path, manifest):
+    manifest_path.write_text(
+        json.dumps(manifest, indent = 2, sort_keys = True) + "\n",
+        encoding = "utf-8",
+    )
+
+
+def package_runtime_closure(primary_dso_path, output_dir, platform):
+    primary_path = Path(primary_dso_path)
+    target_dir = Path(output_dir)
+    target_dir.mkdir(parents = True, exist_ok = True)
+
+    runtime_files = collect_runtime_closure(primary_path)
+    manifest = build_runtime_manifest(primary_path.name, runtime_files)
+
+    archive_path = target_dir / build_runtime_archive_filename(platform)
+    manifest_path = target_dir / build_runtime_manifest_filename(platform)
+
+    create_runtime_archive(archive_path, runtime_files)
+    write_runtime_manifest(manifest_path, manifest)
+    return {
+        "archive_path": archive_path,
+        "manifest_path": manifest_path,
+        "runtime_files": runtime_files,
+    }
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--libxls", required = True)
+    parser.add_argument("--output-dir", required = True)
+    parser.add_argument("--platform", required = True)
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+    result = package_runtime_closure(
+        primary_dso_path = args.libxls,
+        output_dir = args.output_dir,
+        platform = args.platform,
+    )
+    print("Packaged runtime closure:")
+    print("  archive: {}".format(result["archive_path"]))
+    print("  manifest: {}".format(result["manifest_path"]))
+    print("  runtime files: {}".format(", ".join(path.name for path in result["runtime_files"])))
+
+
+if __name__ == "__main__":
+    import sys
+
+    main(sys.argv[1:])

--- a/release_runtime_closure_test.py
+++ b/release_runtime_closure_test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tarfile
+import tempfile
+from pathlib import Path
+import unittest
+
+import release_runtime_closure
+
+
+class ReleaseRuntimeClosureTest(unittest.TestCase):
+    def test_parse_ldd_output_collects_resolved_paths(self):
+        output = """
+            linux-vdso.so.1 (0x00007ffd7c7eb000)
+            libc++.so.1 => /usr/lib/llvm-18/lib/libc++.so.1 (0x0000700000000000)
+            libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000700000001000)
+            /lib64/ld-linux-x86-64.so.2 (0x0000700000002000)
+        """
+
+        resolved = release_runtime_closure.parse_ldd_output(output, Path("/tmp/libxls.so"))
+
+        self.assertEqual(
+            resolved,
+            {
+                "libc++.so.1": Path("/usr/lib/llvm-18/lib/libc++.so.1"),
+                "libc.so.6": Path("/lib/x86_64-linux-gnu/libc.so.6"),
+            },
+        )
+
+    def test_parse_ldd_output_rejects_missing_dependencies(self):
+        output = "libc++.so.1 => not found\n"
+
+        with self.assertRaises(RuntimeError):
+            release_runtime_closure.parse_ldd_output(output, Path("/tmp/libxls.so"))
+
+    def test_collect_runtime_closure_skips_system_path_dependencies(self):
+        dependency_graph = {
+            "/tmp/libxls.so": {
+                "libc++.so.1": Path("/toolchain/lib/libc++.so.1"),
+                "libstdc++.so.6": Path("/lib64/libstdc++.so.6"),
+                "libm.so.6": Path("/lib/libm.so.6"),
+            },
+            "/toolchain/lib/libc++.so.1": {
+                "libc++abi.so.1": Path("/toolchain/lib/libc++abi.so.1"),
+                "libunwind.so.1": Path("/toolchain/lib/libunwind.so.1"),
+                "libgcc_s.so.1": Path("/lib/libgcc_s.so.1"),
+            },
+            "/toolchain/lib/libc++abi.so.1": {},
+            "/toolchain/lib/libunwind.so.1": {
+                "libpthread.so.0": Path("/lib/libpthread.so.0"),
+            },
+        }
+
+        closure = release_runtime_closure.collect_runtime_closure(
+            Path("/tmp/libxls.so"),
+            dependency_resolver = lambda path: dependency_graph[str(path)],
+        )
+
+        self.assertEqual(
+            [path.name for path in closure],
+            ["libc++.so.1", "libc++abi.so.1", "libunwind.so.1"],
+        )
+
+    def test_create_runtime_archive_is_deterministic(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            runtime_one = tmp_path / "libc++.so.1"
+            runtime_two = tmp_path / "libc++abi.so.1"
+            runtime_one.write_bytes(b"runtime-one")
+            runtime_two.write_bytes(b"runtime-two")
+            archive_path = tmp_path / "libxls-runtime-ubuntu2004.tar.gz"
+            second_archive_path = tmp_path / "libxls-runtime-ubuntu2004-copy.tar.gz"
+
+            release_runtime_closure.create_runtime_archive(
+                archive_path,
+                [runtime_two, runtime_one],
+            )
+            release_runtime_closure.create_runtime_archive(
+                second_archive_path,
+                [runtime_two, runtime_one],
+            )
+
+            with tarfile.open(archive_path, "r:gz") as archive:
+                members = archive.getmembers()
+                self.assertEqual(
+                    [member.name for member in members],
+                    ["libc++.so.1", "libc++abi.so.1"],
+                )
+                self.assertTrue(all(member.mtime == 0 for member in members))
+            self.assertEqual(archive_path.read_bytes(), second_archive_path.read_bytes())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/release_runtime_closure_test.py
+++ b/release_runtime_closure_test.py
@@ -18,11 +18,74 @@ import tarfile
 import tempfile
 from pathlib import Path
 import unittest
+from unittest import mock
 
 import release_runtime_closure
 
 
 class ReleaseRuntimeClosureTest(unittest.TestCase):
+    def test_parse_release_target_accepts_macos_arm64(self):
+        self.assertEqual(
+            release_runtime_closure.parse_release_target("macos-arm64").cli_name,
+            "macos-arm64",
+        )
+
+    def test_validate_linux_release_target_rejects_macos_arm64(self):
+        with self.assertRaises(ValueError):
+            release_runtime_closure.validate_linux_release_target("macos-arm64")
+
+    def test_parse_args_accepts_release_target_mismatch_override(self):
+        args = release_runtime_closure.parse_args(
+            [
+                "--libxls",
+                "/tmp/libxls.so",
+                "--output-dir",
+                "/tmp/runtime",
+                "--release-target",
+                "ubuntu2004",
+                "--allow-release-target-mismatch",
+            ]
+        )
+
+        self.assertTrue(args.allow_release_target_mismatch)
+
+    def test_detect_linux_release_target_accepts_ubuntu2004(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os_release_path = Path(tmp_dir) / "os-release"
+            os_release_path.write_text(
+                'ID="ubuntu"\nVERSION_ID="20.04"\n',
+                encoding = "utf-8",
+            )
+
+            self.assertEqual(
+                release_runtime_closure.detect_linux_release_target(os_release_path).cli_name,
+                "ubuntu2004",
+            )
+
+    def test_detect_linux_release_target_accepts_rocky8(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os_release_path = Path(tmp_dir) / "os-release"
+            os_release_path.write_text(
+                'ID="rocky"\nVERSION_ID="8.10"\n',
+                encoding = "utf-8",
+            )
+
+            self.assertEqual(
+                release_runtime_closure.detect_linux_release_target(os_release_path).cli_name,
+                "rocky8",
+            )
+
+    def test_detect_linux_release_target_rejects_unsupported_release(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os_release_path = Path(tmp_dir) / "os-release"
+            os_release_path.write_text(
+                'ID="ubuntu"\nVERSION_ID="24.04"\n',
+                encoding = "utf-8",
+            )
+
+            with self.assertRaises(RuntimeError):
+                release_runtime_closure.detect_linux_release_target(os_release_path)
+
     def test_parse_ldd_output_collects_resolved_paths(self):
         output = """
             linux-vdso.so.1 (0x00007ffd7c7eb000)
@@ -102,6 +165,98 @@ class ReleaseRuntimeClosureTest(unittest.TestCase):
                 )
                 self.assertTrue(all(member.mtime == 0 for member in members))
             self.assertEqual(archive_path.read_bytes(), second_archive_path.read_bytes())
+
+    def test_detect_linux_release_target_matches_supported_release_images(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            ubuntu_os_release = tmp_path / "ubuntu-os-release"
+            ubuntu_os_release.write_text(
+                'ID="ubuntu"\nNAME="Ubuntu"\nVERSION_ID="20.04"\n',
+                encoding = "utf-8",
+            )
+            rocky_os_release = tmp_path / "rocky-os-release"
+            rocky_os_release.write_text(
+                'ID="rocky"\nVERSION_ID="8.10"\n',
+                encoding = "utf-8",
+            )
+
+            self.assertEqual(
+                release_runtime_closure.detect_linux_release_target(ubuntu_os_release).cli_name,
+                "ubuntu2004",
+            )
+            self.assertEqual(
+                release_runtime_closure.detect_linux_release_target(rocky_os_release).cli_name,
+                "rocky8",
+            )
+
+    def test_detect_linux_release_target_rejects_unsupported_hosts(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            unsupported_os_release = tmp_path / "unsupported-os-release"
+            unsupported_os_release.write_text(
+                'ID="ubuntu"\nVERSION_ID="24.04"\n',
+                encoding = "utf-8",
+            )
+
+            with self.assertRaises(RuntimeError):
+                release_runtime_closure.detect_linux_release_target(unsupported_os_release)
+
+    def test_detect_linux_release_target_requires_os_release_file(self):
+        missing_os_release = Path("/tmp/definitely-missing-os-release")
+
+        with self.assertRaises(RuntimeError):
+            release_runtime_closure.detect_linux_release_target(missing_os_release)
+
+    def test_package_runtime_closure_rejects_linux_release_target_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            os_release_path = tmp_path / "os-release"
+            os_release_path.write_text(
+                'ID="ubuntu"\nVERSION_ID="20.04"\n',
+                encoding = "utf-8",
+            )
+            libxls_path = tmp_path / "libxls.so"
+            libxls_path.write_bytes(b"fake-libxls")
+            with mock.patch.object(
+                release_runtime_closure,
+                "collect_runtime_closure",
+                return_value = [],
+            ):
+                with self.assertRaises(RuntimeError):
+                    release_runtime_closure.package_runtime_closure(
+                        primary_dso_path = libxls_path,
+                        output_dir = tmp_path,
+                        release_target = release_runtime_closure.ReleaseTarget.ROCKY8,
+                        os_release_path = os_release_path,
+                    )
+
+    def test_package_runtime_closure_allows_linux_release_target_mismatch_with_override(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            os_release_path = tmp_path / "os-release"
+            os_release_path.write_text(
+                'ID="ubuntu"\nVERSION_ID="20.04"\n',
+                encoding = "utf-8",
+            )
+            libxls_path = tmp_path / "libxls.so"
+            libxls_path.write_bytes(b"fake-libxls")
+            with mock.patch.object(
+                release_runtime_closure,
+                "collect_runtime_closure",
+                return_value = [],
+            ):
+                result = release_runtime_closure.package_runtime_closure(
+                    primary_dso_path = libxls_path,
+                    output_dir = tmp_path,
+                    release_target = release_runtime_closure.ReleaseTarget.ROCKY8,
+                    allow_release_target_mismatch = True,
+                    os_release_path = os_release_path,
+                )
+
+            self.assertEqual(
+                result["archive_path"].name,
+                "libxls-runtime-rocky8.tar.gz",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem Solved
The moving XLS rollout currently selects a newer `libxls` build whose Linux runtime closure is not self-contained for downstream wheel consumers. That shows up later as import-time failures such as missing `libc++.so.1`, and it leaves downstream repos guessing which extra DSOs belong next to `libxls`.

This change makes `xlsynth` publish versioned Linux runtime-closure sidecar assets directly from the release source of truth. It also makes local Linux release naming truthful by default so a host build cannot silently label Ubuntu output as Rocky 8 or vice versa.

## Mental model
For each supported Linux release target, the release flow now emits three related artifacts:
- the existing `libxls-<target>.so(.gz)` payload
- `libxls-runtime-<target>.tar.gz`
- `libxls-runtime-<target>-manifest.json`

The tarball contains the non-system DSOs needed to load the selected `libxls`. The manifest records the runtime basenames that must live beside that shared library at runtime. Local release helpers and the GitHub workflow now speak the same `--release-target` contract, and Linux packaging cross-checks the requested target against the detected host unless an explicit override is passed for deliberate cross-target naming.

## Non-goals
This PR does not change the existing `libxls-<target>.so(.gz)` asset names.

## Tradeoffs
Publishing runtime companions as sidecar assets keeps the release layout additive, which is safer for existing consumers, but it means downstream download/install flows must learn one more artifact family.

The host-matched local packaging guard is stricter than the previous behavior. Unsupported or mismatched Linux hosts now fail fast instead of guessing a release name, and deliberate cross-target packaging requires an explicit override.

## Architecture
`release_runtime_closure.py` inspects the built `libxls.so`, filters out system libraries, and writes a deterministic archive plus manifest for the remaining runtime closure.

`make_local_release.py` and `dist/package_runtime_closure.py` now share one `--release-target` parser and one host/target validation path so local helpers and release packaging cannot drift apart.

`.github/workflows/build-and-release-dylib.yml` now packages Rocky 8 and Ubuntu 20.04 runtime-closure artifacts next to the existing shared-library assets.

## Observability
The new manifest is the machine-readable statement of which runtime basenames belong next to `libxls`.

The helper CLIs print the archive and manifest paths they generated.

When Linux host and requested target disagree, the error names both the requested target and the detected host and points at the explicit override.

## Tests
Validated locally with `python3 -m unittest release_runtime_closure_test.py make_local_release_test.py` and `python3 -m py_compile make_local_release.py release_runtime_closure.py dist/package_runtime_closure.py release_runtime_closure_test.py make_local_release_test.py`.

Validated the Rocky 8 packaging path on a matching Linux host and the macOS helper path locally.