### PR TITLE
aot: add an XLS-owned standalone runtime archive

### DIFF
--- a/.github/workflows/build-and-release-dylib.yml
+++ b/.github/workflows/build-and-release-dylib.yml
@@ -39,8 +39,11 @@ jobs:
         chmod +x bazel-arm64
         ./bazel-arm64 info
         ./bazel-arm64 test -c opt --host_cpu=darwin_arm64 --action_env=MACOSX_DEPLOYMENT_TARGET --macos_minimum_os=11.0 --cxxopt="-std=c++20" --host_cxxopt="-std=c++20" //xls/public:test_c_api_symbols
+        # Publish the standalone AOT archive with the compiler/tool release so
+        # downstream copied executables can link it statically.
         ./bazel-arm64 build -c opt --host_cpu=darwin_arm64 --action_env=MACOSX_DEPLOYMENT_TARGET --macos_minimum_os=11.0 --cxxopt="-std=c++20" --host_cxxopt="-std=c++20" \
           //xls/public:libxls.dylib \
+          //xls/public:xls_aot_runtime \
           //xls/dslx:interpreter_main \
           //xls/dslx/lsp:dslx_ls \
           //xls/tools:opt_main \
@@ -63,6 +66,10 @@ jobs:
         gzip -c bazel-bin/xls/public/libxls.dylib > osx-artifacts-arm64/libxls-arm64.dylib.gz
         shasum -a 256 osx-artifacts-arm64/libxls-arm64.dylib.gz > osx-artifacts-arm64/libxls-arm64.dylib.gz.sha256
         shasum -a 256 bazel-bin/xls/public/libxls.dylib > osx-artifacts-arm64/libxls-arm64.dylib.sha256
+        # The archive is a released link-time artifact, not part of the runtime
+        # dylib payload copied beside executables.
+        cp bazel-bin/xls/public/libxls_aot_runtime.a osx-artifacts-arm64/libxls_aot_runtime-arm64.a
+        shasum -a 256 osx-artifacts-arm64/libxls_aot_runtime-arm64.a > osx-artifacts-arm64/libxls_aot_runtime-arm64.a.sha256
 
         cp bazel-bin/xls/dslx/interpreter_main              osx-artifacts-arm64/dslx_interpreter_main-arm64
         shasum -a 256 osx-artifacts-arm64/dslx_interpreter_main-arm64 > osx-artifacts-arm64/dslx_interpreter_main-arm64.sha256
@@ -160,9 +167,12 @@ jobs:
     - name: Build Bazel target
       run: |
         sudo -u build-user env PATH=$PATH bazelisk test -c opt --action_env=CC=clang --action_env=CXX=clang++ --cxxopt="-std=c++20" --host_cxxopt="-std=c++20" //xls/public:test_c_api_symbols
+        # Publish the standalone AOT archive with the compiler/tool release so
+        # downstream copied executables can link it statically.
         sudo -u build-user env PATH=$PATH bazelisk build -c opt --action_env=CC=clang --action_env=CXX=clang++ --cxxopt="-std=c++20" --host_cxxopt="-std=c++20" \
           //xls/public:libxls.so \
           //xls/public:c_api \
+          //xls/public:xls_aot_runtime \
           //xls/dslx:interpreter_main \
           //xls/dslx/lsp:dslx_ls \
           //xls/tools:opt_main \
@@ -184,6 +194,10 @@ jobs:
         gzip -c bazel-bin/xls/public/libxls.so > rocky8-artifacts/libxls-rocky8.so.gz
         sha256sum rocky8-artifacts/libxls-rocky8.so.gz > rocky8-artifacts/libxls-rocky8.so.gz.sha256
         sha256sum bazel-bin/xls/public/libxls.so > rocky8-artifacts/libxls-rocky8.so.sha256
+        # The archive is a released link-time artifact, not part of the runtime
+        # DSO payload copied beside executables.
+        cp bazel-bin/xls/public/libxls_aot_runtime.a rocky8-artifacts/libxls_aot_runtime-rocky8.a
+        sha256sum rocky8-artifacts/libxls_aot_runtime-rocky8.a > rocky8-artifacts/libxls_aot_runtime-rocky8.a.sha256
         python3 dist/package_runtime_closure.py --libxls bazel-bin/xls/public/libxls.so --output-dir rocky8-artifacts --release-target rocky8
         sha256sum rocky8-artifacts/libxls-runtime-rocky8.tar.gz > rocky8-artifacts/libxls-runtime-rocky8.tar.gz.sha256
         sha256sum rocky8-artifacts/libxls-runtime-rocky8-manifest.json > rocky8-artifacts/libxls-runtime-rocky8-manifest.json.sha256
@@ -315,10 +329,13 @@ jobs:
         sudo -u build-user env PATH=$PATH bazelisk test -c opt --action_env=CC=clang-18 --action_env=CXX=clang++-18 \
           --cxxopt="-std=c++20" --host_cxxopt="-std=c++20" --cxxopt="-stdlib=libc++" --linkopt="-stdlib=libc++" \
           //xls/public:test_c_api_symbols
+        # Publish the standalone AOT archive with the compiler/tool release so
+        # downstream copied executables can link it statically.
         sudo -u build-user env PATH=$PATH bazelisk build -c opt --action_env=CC=clang-18 --action_env=CXX=clang++-18 \
           --cxxopt="-std=c++20" --host_cxxopt="-std=c++20" --cxxopt="-stdlib=libc++" --linkopt="-stdlib=libc++" \
           //xls/public:libxls.so \
           //xls/public:c_api \
+          //xls/public:xls_aot_runtime \
           //xls/dslx:interpreter_main \
           //xls/dslx/lsp:dslx_ls \
           //xls/tools:opt_main \
@@ -340,6 +357,10 @@ jobs:
         gzip -c bazel-bin/xls/public/libxls.so > ubuntu2004-artifacts/libxls-ubuntu2004.so.gz
         sha256sum ubuntu2004-artifacts/libxls-ubuntu2004.so.gz > ubuntu2004-artifacts/libxls-ubuntu2004.so.gz.sha256
         sha256sum bazel-bin/xls/public/libxls.so > ubuntu2004-artifacts/libxls-ubuntu2004.so.sha256
+        # The archive is a released link-time artifact, not part of the runtime
+        # DSO payload copied beside executables.
+        cp bazel-bin/xls/public/libxls_aot_runtime.a ubuntu2004-artifacts/libxls_aot_runtime-ubuntu2004.a
+        sha256sum ubuntu2004-artifacts/libxls_aot_runtime-ubuntu2004.a > ubuntu2004-artifacts/libxls_aot_runtime-ubuntu2004.a.sha256
         python3 dist/package_runtime_closure.py --libxls bazel-bin/xls/public/libxls.so --output-dir ubuntu2004-artifacts --release-target ubuntu2004
         sha256sum ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz > ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz.sha256
         sha256sum ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json > ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json.sha256
@@ -442,6 +463,8 @@ jobs:
           osx-artifacts-arm64/libxls-arm64.dylib.gz \
           osx-artifacts-arm64/libxls-arm64.dylib.gz.sha256 \
           osx-artifacts-arm64/libxls-arm64.dylib.sha256 \
+          osx-artifacts-arm64/libxls_aot_runtime-arm64.a \
+          osx-artifacts-arm64/libxls_aot_runtime-arm64.a.sha256 \
           osx-artifacts-arm64/dslx_interpreter_main-arm64 \
           osx-artifacts-arm64/dslx_interpreter_main-arm64.sha256 \
           osx-artifacts-arm64/dslx_ls-arm64 \
@@ -471,6 +494,8 @@ jobs:
           ubuntu2004-artifacts/libxls-ubuntu2004.so.gz \
           ubuntu2004-artifacts/libxls-ubuntu2004.so.gz.sha256 \
           ubuntu2004-artifacts/libxls-ubuntu2004.so.sha256 \
+          ubuntu2004-artifacts/libxls_aot_runtime-ubuntu2004.a \
+          ubuntu2004-artifacts/libxls_aot_runtime-ubuntu2004.a.sha256 \
           ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz \
           ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz.sha256 \
           ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json \
@@ -502,6 +527,8 @@ jobs:
           rocky8-artifacts/libxls-rocky8.so.gz \
           rocky8-artifacts/libxls-rocky8.so.gz.sha256 \
           rocky8-artifacts/libxls-rocky8.so.sha256 \
+          rocky8-artifacts/libxls_aot_runtime-rocky8.a \
+          rocky8-artifacts/libxls_aot_runtime-rocky8.a.sha256 \
           rocky8-artifacts/libxls-runtime-rocky8.tar.gz \
           rocky8-artifacts/libxls-runtime-rocky8.tar.gz.sha256 \
           rocky8-artifacts/libxls-runtime-rocky8-manifest.json \

--- a/make_local_release.py
+++ b/make_local_release.py
@@ -36,6 +36,12 @@ COMMON_TARGETS = [
     "//xls/tools:block_to_verilog_main"
 ]
 
+# Local releases always carry the static standalone runtime alongside the usual
+# compiler/tool artifacts so consumers can link copied AOT payloads without a
+# runtime `libxls` DSO dependency.
+STATIC_AOT_RUNTIME_TARGET = "//xls/public:xls_aot_runtime"
+STATIC_AOT_RUNTIME_ARCHIVE = "bazel-bin/xls/public/libxls_aot_runtime.a"
+
 LINUX_TARGETS = COMMON_TARGETS + ["//xls/public:libxls.so"]
 MACOS_TARGETS = COMMON_TARGETS + ["//xls/public:libxls.dylib"]
 
@@ -137,6 +143,7 @@ def make_local_release(
     release_target=None,
     allow_release_target_mismatch=False,
 ):
+    """Builds a local release bundle including the standalone AOT archive."""
     # Ensure the output directory exists and is writable
     if os.path.exists(output_dir):
         try:
@@ -146,9 +153,9 @@ def make_local_release(
             sys.exit(1)
     os.makedirs(output_dir, exist_ok=True)
 
-    # Build the targets using Bazel; adjust flags based on the mode.
-    # Include the smoke test targets in the build to ensure they compile with the rest.
-    build_targets = targets
+    # Build the requested tool payload plus the standalone runtime archive that
+    # downstream AOT consumers need at link time.
+    build_targets = targets + [STATIC_AOT_RUNTIME_TARGET]
     if mode == "dbg-asan":
         build_command = [
             "bazel", "build", "-c", "dbg", "--config=asan"
@@ -222,6 +229,16 @@ def make_local_release(
         except PermissionError as e:
             print(f"Permission denied while copying {binary_path}: {e}")
             sys.exit(1)
+
+    # Keep one stable archive name in local releases so downstream packagers do
+    # not need to infer it from the requested DSO target or host platform.
+    static_aot_runtime_dest = os.path.join(output_dir, "libxls_aot_runtime.a")
+    try:
+        shutil.copy2(STATIC_AOT_RUNTIME_ARCHIVE, static_aot_runtime_dest)
+        print(f"Copied {STATIC_AOT_RUNTIME_ARCHIVE} to {static_aot_runtime_dest}")
+    except (FileNotFoundError, PermissionError) as e:
+        print(f"Failed to copy standalone AOT runtime archive: {e}")
+        sys.exit(1)
 
     if "//xls/public:libxls.so" in targets:
         primary_dso_path = os.path.join(output_dir, "libxls.so")

--- a/xls/build_rules/BUILD
+++ b/xls/build_rules/BUILD
@@ -28,9 +28,22 @@ package(
 filegroup(
     name = "release_files",
     srcs = glob(["*.bzl"]) + [
+        ":bundle_static_library",
         ":default_xls_toolchain",
         ":xls_macros_bzl",
     ],
+)
+
+sh_binary(
+    name = "bundle_static_library",
+    srcs = ["bundle_static_library.sh"],
+)
+
+sh_test(
+    name = "bundle_static_library_test",
+    srcs = ["bundle_static_library_test.sh"],
+    args = ["$(location :bundle_static_library)"],
+    data = [":bundle_static_library"],
 )
 
 exports_files(

--- a/xls/build_rules/bundle_static_library.sh
+++ b/xls/build_rules/bundle_static_library.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Copyright 2026 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+output="$1"
+shift
+
+case "$(uname -s)" in
+  Darwin)
+    # Darwin's libtool flattens both object files and nested archives into one
+    # archive; the platform ar implementation does not support MRI scripts.
+    /usr/bin/libtool -static -o "${output}" "$@"
+    ;;
+  Linux)
+    # GNU ar's MRI mode can add archive members without first extracting them,
+    # so duplicate object basenames from different inputs cannot collide.
+    # Older GNU ar releases also treat `~` specially inside MRI scripts. Bazel
+    # module repository paths contain that character, so stage each input behind
+    # a sanitized unique symlink before writing the script consumed by `ar -M`.
+    staging_dir="$(mktemp -d)"
+    trap 'rm -rf "${staging_dir}"' EXIT
+    staged_inputs=()
+    input_index=0
+    for input in "$@"; do
+      case "${input}" in
+        *.a)
+          staged_input="${staging_dir}/input_${input_index}.a"
+          ;;
+        *.lo)
+          staged_input="${staging_dir}/input_${input_index}.lo"
+          ;;
+        *)
+          staged_input="${staging_dir}/input_${input_index}.o"
+          ;;
+      esac
+      ln -s "$(pwd)/${input}" "${staged_input}"
+      staged_inputs+=("${staged_input}")
+      input_index=$((input_index + 1))
+    done
+    {
+      printf 'CREATE %s\n' "${output}"
+      for input in "${staged_inputs[@]}"; do
+        case "${input}" in
+          *.a | *.lo)
+            printf 'ADDLIB %s\n' "${input}"
+            ;;
+          *)
+            printf 'ADDMOD %s\n' "${input}"
+            ;;
+        esac
+      done
+      printf 'SAVE\nEND\n'
+    } | ar -M
+    ;;
+  *)
+    echo "unsupported static-library bundle platform: $(uname -s)" >&2
+    exit 1
+    ;;
+esac

--- a/xls/build_rules/bundle_static_library_test.sh
+++ b/xls/build_rules/bundle_static_library_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2026 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+bundle_tool="${TEST_SRCDIR}/_main/$1"
+workdir="${TEST_TMPDIR}/bundle_static_library_test"
+mkdir -p "${workdir}"
+cd "${workdir}"
+
+cat > member.c <<'EOF'
+int bundled_member(void) { return 1; }
+EOF
+
+cc -c member.c -o member.o
+ar rcs 'libmember~with_tilde.a' member.o
+
+"${bundle_tool}" libbundle.a 'libmember~with_tilde.a'
+ar t libbundle.a | grep -q 'member.o'

--- a/xls/build_rules/xls_static_library_bundle.bzl
+++ b/xls/build_rules/xls_static_library_bundle.bzl
@@ -1,0 +1,120 @@
+# Copyright 2026 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules for static archives that own their full native dependency closure."""
+
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+
+def _append_unique(files, seen_paths, file):
+    if file.path not in seen_paths:
+        files.append(file)
+        seen_paths[file.path] = True
+
+def _collect_bundle_inputs(compilation_outputs, dep_cc_infos):
+    """Returns the object/archive files that must live inside the bundle."""
+    files = []
+    seen_paths = {}
+
+    for object_file in compilation_outputs.pic_objects:
+        _append_unique(files, seen_paths, object_file)
+    for object_file in compilation_outputs.objects:
+        _append_unique(files, seen_paths, object_file)
+
+    for dep_cc_info in dep_cc_infos:
+        for linker_input in dep_cc_info.linking_context.linker_inputs.to_list():
+            for library in linker_input.libraries:
+                if library.pic_static_library != None:
+                    _append_unique(files, seen_paths, library.pic_static_library)
+                elif library.static_library != None:
+                    _append_unique(files, seen_paths, library.static_library)
+                else:
+                    fail(
+                        "xls_static_library_bundle only accepts static C++ dependencies; " +
+                        "found dependency without a static archive from %s" % linker_input.owner,
+                    )
+    return files
+
+def _xls_static_library_bundle_impl(ctx):
+    """Builds one static archive from local sources and dependency archives."""
+    cc_toolchain = find_cpp_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
+    dep_cc_infos = [dep[CcInfo] for dep in ctx.attr.deps]
+    (compilation_context, compilation_outputs) = cc_common.compile(
+        name = ctx.label.name,
+        actions = ctx.actions,
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+        srcs = ctx.files.srcs,
+        public_hdrs = ctx.files.hdrs,
+        compilation_contexts = [dep.compilation_context for dep in dep_cc_infos],
+    )
+    archive = ctx.actions.declare_file("lib%s.a" % ctx.label.name)
+    bundle_inputs = _collect_bundle_inputs(compilation_outputs, dep_cc_infos)
+    ctx.actions.run(
+        executable = ctx.executable._bundle_tool,
+        inputs = bundle_inputs,
+        outputs = [archive],
+        arguments = [archive.path] + [file.path for file in bundle_inputs],
+        mnemonic = "BundleStaticLibrary",
+        progress_message = "Bundling static library %s" % archive.short_path,
+    )
+
+    library_to_link = cc_common.create_library_to_link(
+        actions = ctx.actions,
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+        static_library = archive,
+        pic_static_library = archive,
+    )
+    linker_input = cc_common.create_linker_input(
+        owner = ctx.label,
+        libraries = depset([library_to_link]),
+    )
+    linking_context = cc_common.create_linking_context(
+        linker_inputs = depset([linker_input]),
+    )
+
+    return [
+        CcInfo(
+            compilation_context = compilation_context,
+            linking_context = linking_context,
+        ),
+        DefaultInfo(files = depset([archive])),
+    ]
+
+xls_static_library_bundle = rule(
+    implementation = _xls_static_library_bundle_impl,
+    doc = "Builds one static archive that owns the C++ closure of its dependencies.",
+    attrs = {
+        "srcs": attr.label_list(allow_files = [".cc"]),
+        "hdrs": attr.label_list(allow_files = [".h"]),
+        "deps": attr.label_list(providers = [CcInfo]),
+        "_bundle_tool": attr.label(
+            default = Label("//xls/build_rules:bundle_static_library"),
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    fragments = ["cpp"],
+    provides = [CcInfo],
+    toolchains = use_cpp_toolchain(),
+)

--- a/xls/ir/BUILD
+++ b/xls/ir/BUILD
@@ -566,7 +566,10 @@ cc_library(
 
 cc_library(
     name = "events",
-    srcs = ["events.cc"],
+    srcs = [
+        "events.cc",
+        "events_assertions.cc",
+    ],
     hdrs = ["events.h"],
     deps = [
         ":evaluator_result_cc_proto",

--- a/xls/ir/events.cc
+++ b/xls/ir/events.cc
@@ -118,22 +118,6 @@ void InterpreterEvents::AddTraceCallReturnMessage(
   }
 }
 
-void InterpreterEvents::AddAssertMessage(
-    std::string_view msg, std::optional<SourceInfo> source_info,
-    std::optional<std::string> source_filename) {
-  AssertMessageProto* am = proto_.add_assert_msgs();
-  am->set_message(std::string{msg});
-  if (source_info.has_value() && !source_info->locations.empty()) {
-    const SourceLocation& loc = source_info->locations.front();
-    auto* locp = am->mutable_location();
-    if (source_filename.has_value()) {
-      locp->set_filename(*source_filename);
-    }
-    locp->set_line(loc.lineno().value());
-    locp->set_column(loc.colno().value());
-  }
-}
-
 const ::google::protobuf::RepeatedPtrField<TraceMessageProto>&
 InterpreterEvents::GetTraceMessages() const {
   return proto_.trace_msgs();
@@ -146,15 +130,6 @@ std::vector<std::string> InterpreterEvents::GetTraceMessageStrings() const {
     messages.push_back(t.message());
   }
   return messages;
-}
-
-std::vector<std::string> InterpreterEvents::GetAssertMessages() const {
-  std::vector<std::string> asserts;
-  asserts.reserve(proto_.assert_msgs_size());
-  for (const AssertMessageProto& a : proto_.assert_msgs()) {
-    asserts.push_back(a.message());
-  }
-  return asserts;
 }
 
 void InterpreterEvents::AppendFrom(const InterpreterEvents& other) {

--- a/xls/ir/events.h
+++ b/xls/ir/events.h
@@ -61,6 +61,8 @@ class InterpreterEvents {
   const ::google::protobuf::RepeatedPtrField<TraceMessageProto>& GetTraceMessages() const;
   std::vector<std::string> GetTraceMessageStrings() const;
   std::vector<std::string> GetAssertMessages() const;
+  int64_t GetAssertMessageCount() const;
+  const std::string* GetAssertMessage(int64_t index) const;
 
   void Clear() { proto_.Clear(); }
 

--- a/xls/ir/events_assertions.cc
+++ b/xls/ir/events_assertions.cc
@@ -1,0 +1,63 @@
+// Copyright 2026 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/ir/events.h"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "xls/ir/evaluator_result.pb.h"
+
+namespace xls {
+
+// Keeps assertion-only users from pulling trace formatting dependencies out of
+// `events.cc` while preserving one shared `InterpreterEvents` implementation.
+void InterpreterEvents::AddAssertMessage(
+    std::string_view msg, std::optional<SourceInfo> source_info,
+    std::optional<std::string> source_filename) {
+  AssertMessageProto* am = proto_.add_assert_msgs();
+  am->set_message(std::string{msg});
+  if (source_info.has_value() && !source_info->locations.empty()) {
+    const SourceLocation& loc = source_info->locations.front();
+    auto* locp = am->mutable_location();
+    if (source_filename.has_value()) {
+      locp->set_filename(*source_filename);
+    }
+    locp->set_line(loc.lineno().value());
+    locp->set_column(loc.colno().value());
+  }
+}
+
+std::vector<std::string> InterpreterEvents::GetAssertMessages() const {
+  std::vector<std::string> asserts;
+  asserts.reserve(proto_.assert_msgs_size());
+  for (const AssertMessageProto& a : proto_.assert_msgs()) {
+    asserts.push_back(a.message());
+  }
+  return asserts;
+}
+
+int64_t InterpreterEvents::GetAssertMessageCount() const {
+  return proto_.assert_msgs_size();
+}
+
+const std::string* InterpreterEvents::GetAssertMessage(int64_t index) const {
+  if (index < 0 || index >= proto_.assert_msgs_size()) {
+    return nullptr;
+  }
+  return &proto_.assert_msgs(index).message();
+}
+
+}  // namespace xls

--- a/xls/jit/BUILD
+++ b/xls/jit/BUILD
@@ -76,15 +76,34 @@ cc_library(
     ],
 )
 
+# ABI-only callback layout shared with runtimes that must not depend on the full
+# JIT implementation, such as the standalone AOT static runtime.
+cc_library(
+    name = "generated_code_callback_abi",
+    hdrs = ["generated_code_callback_abi.h"],
+)
+
+cc_library(
+    name = "generated_code_callbacks",
+    srcs = ["generated_code_callbacks.cc"],
+    hdrs = ["generated_code_callbacks.h"],
+    deps = [
+        "//xls/common:math_util",
+        "//xls/ir:events",
+        "@com_google_absl//absl/log:check",
+    ],
+)
+
 cc_library(
     name = "jit_callbacks",
     srcs = ["jit_callbacks.cc"],
     hdrs = ["jit_callbacks.h"],
     deps = [
+        ":generated_code_callbacks",
+        ":generated_code_callback_abi",
         ":jit_channel_queue",
         ":jit_runtime",
         ":observer",
-        "//xls/common:math_util",
         "//xls/ir:events",
         "//xls/ir:format_preference",
         "//xls/ir:proc_elaboration",

--- a/xls/jit/generated_code_callback_abi.h
+++ b/xls/jit/generated_code_callback_abi.h
@@ -1,0 +1,151 @@
+// Copyright 2026 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Lightweight generated-code callback-table ABI shared by LLVM-emitted AOT
+// code and every runtime that can host it.
+//
+// This header intentionally exposes only the binary contract that generated
+// code dereferences directly. Full JIT execution still lives in
+// `jit_callbacks.h`; standalone runtimes include this header so they can satisfy
+// the generated layout without linking the heavyweight JIT implementation.
+
+#ifndef XLS_JIT_GENERATED_CODE_CALLBACK_ABI_H_
+#define XLS_JIT_GENERATED_CODE_CALLBACK_ABI_H_
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace xls {
+
+class InterpreterEvents;
+class JitRuntime;
+struct InstanceContext;
+
+// Manual vtable prefix expected at the start of every generated-code instance
+// context.
+//
+// LLVM-generated code loads these slots by byte offset rather than through C++
+// virtual dispatch, so slot order, field count, and function signatures are all
+// ABI. A runtime may reject a feature at construction time and install aborting
+// handlers for unreachable slots, but it must still preserve this exact table
+// shape for artifacts built against the matching ABI version.
+struct InstanceContextVTable {
+ public:
+  // Appends one already-formatted trace fragment to an in-progress trace buffer.
+  using PerformStringStepFn = void (*)(InstanceContext* thiz, char* step_string,
+                                       std::string* buffer);
+  // Formats one value fragment into an in-progress trace buffer.
+  using PerformFormatStepFn =
+      void (*)(InstanceContext* thiz, JitRuntime* runtime,
+               const uint8_t* type_proto_data, int64_t type_proto_data_size,
+               const uint8_t* value, uint64_t format_u64, std::string* buffer);
+  // Publishes one completed trace buffer to the runtime event sink.
+  using RecordTraceFn = void (*)(InstanceContext* thiz, std::string* buffer,
+                                 int64_t verbosity, InterpreterEvents* events);
+  // Creates the mutable buffer used while lowering one trace statement.
+  using CreateTraceBufferFn = std::string* (*)(InstanceContext* thiz);
+  // Publishes one failed assertion message to the runtime event sink.
+  using RecordAssertionFn = void (*)(InstanceContext* thiz, const char* msg,
+                                     InterpreterEvents* events);
+  // Receives one raw proc value from the queue selected at AOT compile time.
+  using QueueReceiveWrapperFn = bool (*)(InstanceContext* thiz,
+                                         int64_t queue_index, uint8_t* buffer);
+  // Sends one raw proc value to the queue selected at AOT compile time.
+  using QueueSendWrapperFn = void (*)(InstanceContext* instance_context,
+                                      int64_t queue_index, const uint8_t* data);
+  // Records the selected `next_value` node for proc execution bookkeeping.
+  using RecordActiveNextValueFn = void (*)(InstanceContext* thiz,
+                                           int64_t param_id, int64_t next_id);
+  // Reports one computed node result to an optional runtime observer.
+  using RecordNodeResultFn = void (*)(InstanceContext* thiz, int64_t node_ptr,
+                                      const uint8_t* data);
+  // Allocates aligned scratch storage requested by generated code.
+  using AllocateBufferFn = void* (*)(InstanceContext* thiz, int64_t byte_size,
+                                     int64_t alignment);
+  // Releases scratch storage returned by `AllocateBufferFn`.
+  using DeallocateBufferFn = void (*)(InstanceContext* thiz, void* buffer);
+  // Records the chosen register-write node for block execution bookkeeping.
+  using RecordActiveRegisterWriteFn = void (*)(InstanceContext* thiz,
+                                               int64_t register_no,
+                                               int64_t register_write_no);
+
+  // Builds the full-JIT callback table used by the ordinary in-process runtime.
+  explicit InstanceContextVTable();
+  // Builds a callback table for runtimes that provide their own implementations.
+  InstanceContextVTable(PerformStringStepFn perform_string_step,
+                        PerformFormatStepFn perform_format_step,
+                        RecordTraceFn record_trace,
+                        CreateTraceBufferFn create_trace_buffer,
+                        RecordAssertionFn record_assertion,
+                        QueueReceiveWrapperFn queue_receive_wrapper,
+                        QueueSendWrapperFn queue_send_wrapper,
+                        RecordActiveNextValueFn record_active_next_value,
+                        RecordNodeResultFn record_node_result,
+                        AllocateBufferFn allocate_buffer,
+                        DeallocateBufferFn deallocate_buffer,
+                        RecordActiveRegisterWriteFn
+                            record_active_register_write)
+      : perform_string_step(perform_string_step),
+        perform_format_step(perform_format_step),
+        record_trace(record_trace),
+        create_trace_buffer(create_trace_buffer),
+        record_assertion(record_assertion),
+        queue_receive_wrapper(queue_receive_wrapper),
+        queue_send_wrapper(queue_send_wrapper),
+        record_active_next_value(record_active_next_value),
+        record_node_result(record_node_result),
+        allocate_buffer(allocate_buffer),
+        deallocate_buffer(deallocate_buffer),
+        record_active_register_write(record_active_register_write) {}
+
+  // Appends one literal trace fragment.
+  const PerformStringStepFn perform_string_step;
+  // Appends one formatted-value trace fragment.
+  const PerformFormatStepFn perform_format_step;
+  // Publishes one finished trace statement.
+  const RecordTraceFn record_trace;
+  // Allocates the trace buffer consumed by `record_trace`.
+  const CreateTraceBufferFn create_trace_buffer;
+  // Publishes one failed assertion message.
+  const RecordAssertionFn record_assertion;
+  // Receives one raw value from a proc channel queue.
+  const QueueReceiveWrapperFn queue_receive_wrapper;
+  // Sends one raw value to a proc channel queue.
+  const QueueSendWrapperFn queue_send_wrapper;
+  // Records one active proc `next_value`.
+  const RecordActiveNextValueFn record_active_next_value;
+  // Reports one raw node result to an observer.
+  const RecordNodeResultFn record_node_result;
+  // Allocates generated-code scratch storage.
+  const AllocateBufferFn allocate_buffer;
+  // Releases generated-code scratch storage.
+  const DeallocateBufferFn deallocate_buffer;
+  // Records one active block register write.
+  const RecordActiveRegisterWriteFn record_active_register_write;
+
+  // Number of ABI slots that generated code may index by offset.
+  static constexpr int64_t kVTableLength = 12;
+  // Plain function-pointer view used to validate the ABI layout size.
+  using VTableArrayType = std::array<void (*)(), kVTableLength>;
+};
+
+// Generated code assumes the manual table is exactly a dense pointer array.
+static_assert(sizeof(InstanceContextVTable) ==
+              sizeof(InstanceContextVTable::VTableArrayType));
+
+}  // namespace xls
+
+#endif  // XLS_JIT_GENERATED_CODE_CALLBACK_ABI_H_

--- a/xls/jit/generated_code_callbacks.cc
+++ b/xls/jit/generated_code_callbacks.cc
@@ -1,0 +1,48 @@
+// Copyright 2026 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/jit/generated_code_callbacks.h"
+
+#include <cstdlib>
+
+#include "absl/log/check.h"
+#include "xls/common/math_util.h"
+#include "xls/ir/events.h"
+
+namespace xls::generated_code_callbacks {
+
+void RecordAssertion(InstanceContext* thiz, const char* msg,
+                     InterpreterEvents* events) {
+  events->AddAssertMessage(msg);
+}
+
+void* AllocateBuffer(InstanceContext* thiz, int64_t byte_size,
+                     int64_t alignment) {
+  // The c11 std §7.22.3 states that std::aligned_alloc must be called with
+  // size as a multiple of the alignment. The c17 standard removes this
+  // simply saying that bad alignments fail. For all allocators except the ASAN
+  // one the looser rules are followed and any relatively normal alignment llvm
+  // supports is allowed for any size but asan specifically follows the older
+  // spec. Overallocate to support this behavior.
+  int64_t adj_size = RoundUpToNearest(byte_size, alignment);
+  void* res = std::aligned_alloc(alignment, adj_size);
+  CHECK(res != nullptr) << "Null alloc with " << byte_size
+                        << " (adjusted to: " << adj_size
+                        << ") aligned at: " << alignment;
+  return res;
+}
+
+void DeallocateBuffer(InstanceContext* thiz, void* ptr) { free(ptr); }
+
+}  // namespace xls::generated_code_callbacks

--- a/xls/jit/generated_code_callbacks.h
+++ b/xls/jit/generated_code_callbacks.h
@@ -1,0 +1,43 @@
+// Copyright 2026 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_JIT_GENERATED_CODE_CALLBACKS_H_
+#define XLS_JIT_GENERATED_CODE_CALLBACKS_H_
+
+#include <cstdint>
+
+namespace xls {
+
+class InterpreterEvents;
+struct InstanceContext;
+
+namespace generated_code_callbacks {
+
+// Shared assertion callback used by every XLS runtime that executes the
+// generated-code callback ABI.
+void RecordAssertion(InstanceContext* thiz, const char* msg,
+                     InterpreterEvents* events);
+
+// Shared generated-code scratch allocator used by every XLS runtime that
+// executes the generated-code callback ABI.
+void* AllocateBuffer(InstanceContext* thiz, int64_t byte_size,
+                     int64_t alignment);
+
+// Releases storage returned by `AllocateBuffer`.
+void DeallocateBuffer(InstanceContext* thiz, void* ptr);
+
+}  // namespace generated_code_callbacks
+}  // namespace xls
+
+#endif  // XLS_JIT_GENERATED_CODE_CALLBACKS_H_

--- a/xls/jit/jit_callbacks.cc
+++ b/xls/jit/jit_callbacks.cc
@@ -22,12 +22,12 @@
 #include "absl/log/check.h"
 #include "absl/strings/str_cat.h"
 #include "absl/types/span.h"
-#include "xls/common/math_util.h"
 #include "xls/ir/events.h"
 #include "xls/ir/format_preference.h"
 #include "xls/ir/type.h"
 #include "xls/ir/value.h"
 #include "xls/ir/xls_type.pb.h"
+#include "xls/jit/generated_code_callbacks.h"
 #include "xls/jit/jit_runtime.h"
 
 namespace xls {
@@ -60,11 +60,6 @@ void RecordTrace(InstanceContext* thiz, std::string* buffer, int64_t verbosity,
 std::string* CreateTraceBuffer(InstanceContext* thiz) {
   return new std::string();
 }
-void RecordAssertion(InstanceContext* thiz, const char* msg,
-                     InterpreterEvents* events) {
-  events->AddAssertMessage(msg);
-}
-
 bool QueueReceiveWrapper(InstanceContext* thiz, int64_t queue_index,
                          uint8_t* buffer) {
   return thiz->channel_queues[queue_index]->ReadRaw(buffer);
@@ -92,39 +87,19 @@ void RecordActiveRegisterWrite(InstanceContext* thiz, int64_t register_no,
   thiz->active_register_writes[register_no].push_back(register_write_no);
 }
 
-void* AllocateBuffer(InstanceContext* thiz, int64_t byte_size,
-                     int64_t alignment) {
-  // The c11 std §7.22.3 states that std::aligned_alloc must be called with
-  // size as a multiple of the alignment. The c17 standard removes this
-  // simply saying that bad alignments fail. For all allocators except the ASAN
-  // one the looser rules are followed and any relatively normal alignment llvm
-  // supports is allowed for any size but asan specifically follows the older
-  // spec. Overallocate to support this behavior.
-  int64_t adj_size = RoundUpToNearest(byte_size, alignment);
-  void* res = std::aligned_alloc(alignment, adj_size);
-  CHECK(res != nullptr) << "Null alloc with " << byte_size
-                        << " (adjusted to: " << adj_size
-                        << ") aligned at: " << alignment;
-  return res;
-}
-
-void DeallocateBuffer(InstanceContext* thiz, void* ptr) { free(ptr); }
-
 }  // namespace
 
+// Installs the full-JIT implementations behind the ABI-only constructor shape
+// declared in `generated_code_callback_abi.h`.
 InstanceContextVTable::InstanceContextVTable()
-    : perform_string_step(&PerformStringStep),
-      perform_format_step(&PerformFormatStep),
-      record_trace(&RecordTrace),
-      create_trace_buffer(&CreateTraceBuffer),
-      record_assertion(&RecordAssertion),
-      queue_receive_wrapper(&QueueReceiveWrapper),
-      queue_send_wrapper(&QueueSendWrapper),
-      record_active_next_value(&RecordActiveNextValue),
-      record_node_result(&RecordNodeResult),
-      allocate_buffer(&AllocateBuffer),
-      deallocate_buffer(&DeallocateBuffer),
-      record_active_register_write(&RecordActiveRegisterWrite) {}
+    : InstanceContextVTable(
+          &PerformStringStep, &PerformFormatStep, &RecordTrace,
+          &CreateTraceBuffer, &generated_code_callbacks::RecordAssertion,
+          &QueueReceiveWrapper,
+          &QueueSendWrapper, &RecordActiveNextValue, &RecordNodeResult,
+          &generated_code_callbacks::AllocateBuffer,
+          &generated_code_callbacks::DeallocateBuffer,
+          &RecordActiveRegisterWrite) {}
 
 Type* InstanceContext::ParseTypeFromProto(absl::Span<uint8_t const> data) {
   TypeProto proto;

--- a/xls/jit/jit_callbacks.h
+++ b/xls/jit/jit_callbacks.h
@@ -15,11 +15,8 @@
 #ifndef XLS_JIT_JIT_CALLBACKS_H_
 #define XLS_JIT_JIT_CALLBACKS_H_
 
-#include <array>
-#include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -30,102 +27,28 @@
 #include "xls/ir/proc_elaboration.h"
 #include "xls/ir/type.h"
 #include "xls/ir/type_manager.h"
+#include "xls/jit/generated_code_callback_abi.h"
 #include "xls/jit/jit_channel_queue.h"
 #include "xls/jit/jit_runtime.h"
 #include "xls/jit/observer.h"
 
 namespace xls {
 
-struct InstanceContext;
-// Manual vtable of an InstanceContext. Called directly from LLVM jit code.
+// Full in-process execution context used by ordinary JIT evaluation.
 //
-// TODO(allight): Instead of using this Vtable passed as an argument we could
-// use the ORC-jit dynamic linking functionality we use to implement MSAN
-// support. Unfortunately that would require us to ensure that symbols are
-// exported correctly which can be tricky. This way we don't need to deal with
-// the linker at all.
-struct InstanceContextVTable {
- public:
-  explicit InstanceContextVTable();
-
-  using PerformStringStepFn = void (*)(InstanceContext* thiz, char* step_string,
-                                       std::string* buffer);
-  // This is a shim to let JIT code add a new trace fragment to an existing
-  // trace buffer.
-  const PerformStringStepFn perform_string_step;
-  using PerformFormatStepFn =
-      void (*)(InstanceContext* thiz, JitRuntime* runtime,
-               const uint8_t* type_proto_data, int64_t type_proto_data_size,
-               const uint8_t* value, uint64_t format_u64, std::string* buffer);
-  const PerformFormatStepFn perform_format_step;
-
-  using RecordTraceFn = void (*)(InstanceContext* thiz, std::string* buffer,
-                                 int64_t verbosity, InterpreterEvents* events);
-  // This a shim to let JIT code record a completed trace as an interpreter
-  // event.
-  const RecordTraceFn record_trace;
-
-  using CreateTraceBufferFn = std::string* (*)(InstanceContext * thiz);
-  // This is a shim to let JIT code create a buffer for accumulating trace
-  // fragments.
-  const CreateTraceBufferFn create_trace_buffer;
-
-  using RecordAssertionFn = void (*)(InstanceContext* thiz, const char* msg,
-                                     InterpreterEvents* events);
-  // This a shim to let JIT code record an assertion failure as an interpreter
-  // event.
-  const RecordAssertionFn record_assertion;
-
-  using QueueReceiveWrapperFn = bool (*)(InstanceContext* thiz,
-                                         int64_t queue_index, uint8_t* buffer);
-  const QueueReceiveWrapperFn queue_receive_wrapper;
-
-  using QueueSendWrapperFn = void (*)(InstanceContext* instance_context,
-                                      int64_t queue_index, const uint8_t* data);
-  const QueueSendWrapperFn queue_send_wrapper;
-
-  using RecordActiveNextValueFn = void (*)(InstanceContext* thiz,
-                                           int64_t param_id, int64_t next_id);
-  // This is a shim to let JIT code record the activation of a `next_value`
-  // node.
-  const RecordActiveNextValueFn record_active_next_value;
-
-  using RecordNodeResultFn = void (*)(InstanceContext* thiz, int64_t node_ptr,
-                                      const uint8_t* data);
-  // This is a shim to let JIT record what data was recorded for each node. The
-  // 'node_ptr' is the constant pointer value of the node at the time the jitted
-  // code was created. Whether it is a valid pointer to dereference depends on
-  // execution context. It will be globally unique and consistent however.
-  //
-  // Data is in JIT data format and can be read using the appropriate type
-  // information for the node.
-  const RecordNodeResultFn record_node_result;
-
-  using AllocateBufferFn = void* (*)(InstanceContext * thiz, int64_t byte_size,
-                                     int64_t alignment);
-  // This is a shim to let the JIT allocate a large buffer on the heap for cases
-  // where its required to avoid blowing out the stack.
-  const AllocateBufferFn allocate_buffer;
-
-  using DeallocateBufferFn = void (*)(InstanceContext* thiz, void* buffer);
-  // This is a shim to let the JIT deallocate the buffer returned by
-  // allocate_buffer.
-  const DeallocateBufferFn deallocate_buffer;
-
-  using RecordActiveRegisterWriteFn = void (*)(InstanceContext* thiz,
-                                               int64_t register_no,
-                                               int64_t register_write_no);
-  // This is a shim to let JIT code record the activation of a register write
-  // node.
-  const RecordActiveRegisterWriteFn record_active_register_write;
-};
-
-// Data structure passed to the JITted function which contains instance-specific
-// execution-relevant information and function pointers. Used for JITted procs.
+// The ABI-visible callback prefix now lives in
+// `generated_code_callback_abi.h` so
+// standalone runtimes can satisfy generated code without depending on the rest
+// of this type. The remaining fields here are intentionally heavyweight JIT
+// state for proc/block execution, type materialization, and observers.
 struct InstanceContext {
  public:
+  // Creates the minimal full-JIT context used by function evaluation.
   static InstanceContext CreateForFunc() { return InstanceContext(); }
+  // Creates the minimal full-JIT context used by block evaluation.
   static InstanceContext CreateForBlock() { return InstanceContext(); }
+  // Creates a proc context with the instance and compile-time queue ordering
+  // expected by generated send/receive callbacks.
   static InstanceContext CreateForProc(ProcInstance* inst,
                                        std::vector<JitChannelQueue*> queues) {
     InstanceContext ret;
@@ -134,7 +57,7 @@ struct InstanceContext {
     return ret;
   }
 
-  // Offsets in the vtable the LLVM can use to grab the actual function pointer.
+  // Offsets in the ABI prefix that LLVM-generated code uses to load callbacks.
   static constexpr int64_t kPerformStringStepOffset =
       offsetof(InstanceContextVTable, perform_string_step);
   static constexpr int64_t kPerformFormatStepOffset =
@@ -159,9 +82,10 @@ struct InstanceContext {
       offsetof(InstanceContextVTable, deallocate_buffer);
   static constexpr int64_t kRecordActiveRegisterWrite =
       offsetof(InstanceContextVTable, record_active_register_write);
-  static constexpr int64_t kVTableLength = 12;
-  using VTableArrayType = std::array<void (*)(), kVTableLength>;
+  static constexpr int64_t kVTableLength = InstanceContextVTable::kVTableLength;
+  using VTableArrayType = InstanceContextVTable::VTableArrayType;
 
+  // Returns whether an offset is one of the ABI-visible callback slots.
   static constexpr bool IsVtableOffset(int64_t v) {
     return v == kPerformFormatStepOffset || v == kPerformStringStepOffset ||
            v == kRecordTraceOffset || v == kCreateTraceBufferOffset ||
@@ -171,6 +95,8 @@ struct InstanceContext {
            v == kDeallocateBufferOffset || v == kRecordActiveRegisterWrite;
   }
 
+  // Materializes the serialized type needed by format callbacks for this
+  // in-process runtime instance.
   Type* ParseTypeFromProto(absl::Span<uint8_t const> data);
 
   InstanceContextVTable vtable;
@@ -200,8 +126,6 @@ struct InstanceContext {
 };
 
 static_assert(offsetof(InstanceContext, vtable) == 0);
-static_assert(sizeof(InstanceContextVTable) ==
-              sizeof(InstanceContext::VTableArrayType));
 
 }  // namespace xls
 

--- a/xls/public/BUILD
+++ b/xls/public/BUILD
@@ -18,6 +18,7 @@ load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//xls/build_rules:py_oss_defs.bzl", "pytype_strict_binary")
+load("//xls/build_rules:xls_static_library_bundle.bzl", "xls_static_library_bundle")
 load("//xls/public:xls_public_macros.oss.bzl", "libxls_dylib_binary", "py_test_c_api_symbols")
 
 package(
@@ -312,6 +313,38 @@ cc_library(
         "//xls/ir:value",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/types:span",
+    ],
+)
+
+# Public static archive linked into copied standalone AOT executables so they do
+# not need a runtime `libxls` DSO. This deliberately bundles the LLVM-free
+# runtime closure into one archive instead of asking downstream consumers to
+# reconstruct the same link line independently.
+xls_static_library_bundle(
+    name = "xls_aot_runtime",
+    srcs = ["standalone_aot_runtime.cc"],
+    hdrs = ["standalone_aot_runtime.h"],
+    deps = [
+        "//xls/ir:events",
+        "//xls/ir:value",
+        "//xls/jit:aot_runtime",
+        "//xls/jit:generated_code_callbacks",
+        "//xls/jit:generated_code_callback_abi",
+        "//xls/jit:type_layout",
+    ],
+)
+
+# Locks down the direct-call/assertion contract and future trace rejection for
+# the static standalone runtime surface.
+cc_test(
+    name = "standalone_aot_runtime_test",
+    srcs = ["standalone_aot_runtime_test.cc"],
+    linkstatic = True,
+    deps = [
+        ":xls_aot_runtime",
+        "//xls/jit:generated_code_callback_abi",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
     ],
 )
 

--- a/xls/public/standalone_aot_runtime.cc
+++ b/xls/public/standalone_aot_runtime.cc
@@ -1,0 +1,196 @@
+// Copyright 2026 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/public/standalone_aot_runtime.h"
+
+#include <bit>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+#include <string>
+
+#include "xls/ir/events.h"
+#include "xls/jit/generated_code_callback_abi.h"
+#include "xls/jit/generated_code_callbacks.h"
+
+namespace {
+
+// Native function shape emitted for function-only standalone AOT artifacts.
+using StandaloneAotFunctionEntrypoint = int64_t (*)(
+    const uint8_t* const* inputs, uint8_t* const* outputs, void* temp_buffer,
+    xls::InterpreterEvents* events, xls::InstanceContext* instance_context,
+    xls::JitRuntime* jit_runtime, int64_t continuation_point);
+
+// Fails fast if generated code reaches a callback that the negotiated feature
+// set promised would be unreachable in this first standalone runtime.
+[[noreturn]] void UnsupportedCallback() { std::abort(); }
+
+// Trace string fragments are unsupported until trace lowering is added here.
+void UnsupportedPerformStringStep(xls::InstanceContext* thiz, char* step_string,
+                                  std::string* buffer) {
+  UnsupportedCallback();
+}
+
+// Trace value formatting still depends on the full JIT runtime today.
+void UnsupportedPerformFormatStep(xls::InstanceContext* thiz,
+                                  xls::JitRuntime* runtime,
+                                  const uint8_t* type_proto_data,
+                                  int64_t type_proto_data_size,
+                                  const uint8_t* value, uint64_t format_u64,
+                                  std::string* buffer) {
+  UnsupportedCallback();
+}
+
+// Completed traces are not part of the assertion-only runtime contract.
+void UnsupportedRecordTrace(xls::InstanceContext* thiz, std::string* buffer,
+                            int64_t verbosity,
+                            xls::InterpreterEvents* events) {
+  UnsupportedCallback();
+}
+
+// Trace buffers are intentionally unavailable until trace support lands.
+std::string* UnsupportedCreateTraceBuffer(xls::InstanceContext* thiz) {
+  UnsupportedCallback();
+}
+
+// Proc queue operations are invalid for function-only standalone artifacts.
+bool UnsupportedQueueReceiveWrapper(xls::InstanceContext* thiz,
+                                    int64_t queue_index, uint8_t* buffer) {
+  UnsupportedCallback();
+}
+
+// Proc queue operations are invalid for function-only standalone artifacts.
+void UnsupportedQueueSendWrapper(xls::InstanceContext* thiz,
+                                 int64_t queue_index, const uint8_t* data) {
+  UnsupportedCallback();
+}
+
+// Proc bookkeeping is invalid for function-only standalone artifacts.
+void UnsupportedRecordActiveNextValue(xls::InstanceContext* thiz,
+                                      int64_t param_id, int64_t next_id) {
+  UnsupportedCallback();
+}
+
+// Observer callbacks are outside the standalone runtime contract.
+void UnsupportedRecordNodeResult(xls::InstanceContext* thiz, int64_t node_ptr,
+                                 const uint8_t* data) {
+  UnsupportedCallback();
+}
+
+// Block bookkeeping is invalid for function-only standalone artifacts.
+void UnsupportedRecordActiveRegisterWrite(xls::InstanceContext* thiz,
+                                          int64_t register_no,
+                                          int64_t register_write_no) {
+  UnsupportedCallback();
+}
+
+// Callback table installed behind the ABI-visible prefix of the runtime
+// object. Unsupported slots stay present so generated-code offsets remain ABI
+// compatible, but they abort if a non-negotiated feature somehow reaches them.
+struct StandaloneAotCallbackTable final : xls::InstanceContextVTable {
+  StandaloneAotCallbackTable()
+      : xls::InstanceContextVTable(
+            &UnsupportedPerformStringStep, &UnsupportedPerformFormatStep,
+            &UnsupportedRecordTrace, &UnsupportedCreateTraceBuffer,
+            &xls::generated_code_callbacks::RecordAssertion,
+            &UnsupportedQueueReceiveWrapper,
+            &UnsupportedQueueSendWrapper, &UnsupportedRecordActiveNextValue,
+            &UnsupportedRecordNodeResult,
+            &xls::generated_code_callbacks::AllocateBuffer,
+            &xls::generated_code_callbacks::DeallocateBuffer,
+            &UnsupportedRecordActiveRegisterWrite) {}
+};
+
+// Feature bits this first standalone runtime can actually execute.
+constexpr uint32_t kSupportedFeatures =
+    XLS_STANDALONE_AOT_RUNTIME_FEATURE_ASSERTIONS;
+
+}  // namespace
+
+// Runtime object whose first bytes are the callback table seen by generated
+// code. Assertion storage reuses the same `InterpreterEvents` path as the full
+// JIT runtime so standalone execution does not grow a second event model.
+struct xls_standalone_aot_runtime {
+  StandaloneAotCallbackTable vtable;
+  xls::InterpreterEvents events;
+};
+
+// Validates feature negotiation before allocating the standalone runtime
+// object, so unreachable callbacks remain a construction-time contract.
+enum xls_standalone_aot_runtime_status xls_standalone_aot_runtime_create(
+    uint32_t abi_version, uint32_t required_features,
+    struct xls_standalone_aot_runtime** out) {
+  if (abi_version != XLS_STANDALONE_AOT_ABI_VERSION) {
+    *out = nullptr;
+    return XLS_STANDALONE_AOT_RUNTIME_STATUS_UNSUPPORTED_ABI_VERSION;
+  } else if ((required_features & ~kSupportedFeatures) != 0) {
+    *out = nullptr;
+    return XLS_STANDALONE_AOT_RUNTIME_STATUS_UNSUPPORTED_FEATURE;
+  } else {
+    auto* runtime = new (std::nothrow) xls_standalone_aot_runtime;
+    if (runtime == nullptr) {
+      *out = nullptr;
+      return XLS_STANDALONE_AOT_RUNTIME_STATUS_ALLOCATION_FAILED;
+    }
+    *out = runtime;
+    return XLS_STANDALONE_AOT_RUNTIME_STATUS_OK;
+  }
+}
+
+// Releases the runtime object and its owned event storage.
+void xls_standalone_aot_runtime_free(
+    struct xls_standalone_aot_runtime* runtime) {
+  delete runtime;
+}
+
+// Clears event payloads while keeping one reusable runtime object alive.
+void xls_standalone_aot_runtime_clear_events(
+    struct xls_standalone_aot_runtime* runtime) {
+  runtime->events.Clear();
+}
+
+// Exposes the number of assertion messages currently retained by the runtime.
+size_t xls_standalone_aot_runtime_get_assert_message_count(
+    const struct xls_standalone_aot_runtime* runtime) {
+  return runtime->events.GetAssertMessageCount();
+}
+
+// Returns one retained assertion message, or null when the caller asks past the
+// retained range.
+const char* xls_standalone_aot_runtime_get_assert_message(
+    const struct xls_standalone_aot_runtime* runtime, size_t index) {
+  const std::string* message = runtime->events.GetAssertMessage(index);
+  if (message == nullptr) {
+    return nullptr;
+  } else {
+    return message->c_str();
+  }
+}
+
+// Calls one metadata-matched direct-call artifact through the standalone ABI
+// and reports the assertion count observed after that invocation.
+int64_t xls_standalone_aot_entrypoint_trampoline(
+    uintptr_t function_ptr, const uint8_t* const* inputs,
+    uint8_t* const* outputs, void* temp_buffer,
+    struct xls_standalone_aot_runtime* runtime, int64_t continuation_point,
+    size_t* assert_messages_count_out) {
+  StandaloneAotFunctionEntrypoint entrypoint =
+      std::bit_cast<StandaloneAotFunctionEntrypoint>(function_ptr);
+  int64_t continuation = entrypoint(
+      inputs, outputs, temp_buffer, &runtime->events,
+      reinterpret_cast<xls::InstanceContext*>(&runtime->vtable),
+      /*jit_runtime=*/nullptr, continuation_point);
+  *assert_messages_count_out = runtime->events.GetAssertMessageCount();
+  return continuation;
+}

--- a/xls/public/standalone_aot_runtime.h
+++ b/xls/public/standalone_aot_runtime.h
@@ -1,0 +1,123 @@
+// Copyright 2026 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_PUBLIC_STANDALONE_AOT_RUNTIME_H_
+#define XLS_PUBLIC_STANDALONE_AOT_RUNTIME_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Opaque owner of the assertion-only runtime state used by standalone AOT
+// function artifacts.
+struct xls_standalone_aot_runtime;
+
+// Version of the standalone runtime ABI understood by this static artifact.
+//
+// Generated artifacts and runtimes are intentionally same-version only: callers
+// should rebuild artifacts whenever related compiler/runtime code changes
+// rather than attempting cross-version execution.
+#define XLS_STANDALONE_AOT_ABI_VERSION 1u
+
+// Feature bits that generated standalone artifacts declare at runtime creation.
+//
+// Traces are intentionally reserved in the first landing even though the
+// runtime rejects them today. Current trace lowering needs value-formatting
+// support that remains part of the full JIT runtime; keeping the feature bit in
+// the ABI now gives the later trace implementation an explicit extension path
+// instead of forcing another ownership redesign.
+enum xls_standalone_aot_runtime_feature {
+  // The artifact may emit assertion callbacks that this runtime records.
+  XLS_STANDALONE_AOT_RUNTIME_FEATURE_ASSERTIONS = 1u << 0,
+  // Reserved extension bit for a future trace-capable standalone runtime.
+  XLS_STANDALONE_AOT_RUNTIME_FEATURE_TRACES = 1u << 1,
+};
+
+// Result codes for constructing a standalone AOT runtime context.
+enum xls_standalone_aot_runtime_status {
+  // Construction succeeded and `out` owns a valid runtime context.
+  XLS_STANDALONE_AOT_RUNTIME_STATUS_OK = 0,
+  // The artifact/runtime ABI versions differ and must not be mixed.
+  XLS_STANDALONE_AOT_RUNTIME_STATUS_UNSUPPORTED_ABI_VERSION = 1,
+  // The artifact requested a feature that this runtime does not implement.
+  XLS_STANDALONE_AOT_RUNTIME_STATUS_UNSUPPORTED_FEATURE = 2,
+  // Runtime-owned storage could not be allocated.
+  XLS_STANDALONE_AOT_RUNTIME_STATUS_ALLOCATION_FAILED = 3,
+};
+
+// Creates a function-only standalone AOT runtime context.
+//
+// The first landing accepts assertion-bearing artifacts and rejects artifacts
+// that require trace support. The returned object is owned by the caller and
+// must be freed with `xls_standalone_aot_runtime_free`. `out` must be non-null;
+// passing a null output slot is a caller bug because creation always writes the
+// result there, including on failure.
+enum xls_standalone_aot_runtime_status xls_standalone_aot_runtime_create(
+    uint32_t abi_version, uint32_t required_features,
+    struct xls_standalone_aot_runtime** out);
+
+// Releases a runtime context returned by `xls_standalone_aot_runtime_create`.
+//
+// This also releases all recorded assertion messages. Callers must not pass
+// null or use the runtime again afterward; doing so would dereference freed
+// storage in the C implementation.
+void xls_standalone_aot_runtime_free(
+    struct xls_standalone_aot_runtime* runtime);
+
+// Drops all assertion messages while keeping the runtime reusable.
+//
+// Message pointers previously returned by
+// `xls_standalone_aot_runtime_get_assert_message` become invalid immediately
+// after this call.
+void xls_standalone_aot_runtime_clear_events(
+    struct xls_standalone_aot_runtime* runtime);
+
+// Returns the number of assertion messages recorded since the last clear.
+//
+// `runtime` must be a live runtime returned by `create`; passing null or a
+// freed runtime would dereference invalid storage.
+size_t xls_standalone_aot_runtime_get_assert_message_count(
+    const struct xls_standalone_aot_runtime* runtime);
+
+// Returns an assertion message owned by `runtime`, or `NULL` when `index` is
+// out of range. The returned pointer stays valid until events are cleared or
+// the runtime is freed. `runtime` must remain live for the whole use of the
+// returned pointer.
+const char* xls_standalone_aot_runtime_get_assert_message(
+    const struct xls_standalone_aot_runtime* runtime, size_t index);
+
+// Invokes a function-only AOT entrypoint through the XLS-owned standalone
+// runtime. The function pointer must address an unpacked XLS AOT function
+// entrypoint produced for the same ABI version.
+//
+// The runtime borrows `inputs`, `outputs`, and `temp_buffer`; callers keep
+// ownership of all three. Passing a pointer for another signature or ABI would
+// make the generated code interpret the argument layout incorrectly, so only
+// metadata-matched direct-call artifacts may use this trampoline.
+// `assert_messages_count_out` must be non-null so the caller can observe the
+// post-call assertion count.
+int64_t xls_standalone_aot_entrypoint_trampoline(
+    uintptr_t function_ptr, const uint8_t* const* inputs,
+    uint8_t* const* outputs, void* temp_buffer,
+    struct xls_standalone_aot_runtime* runtime, int64_t continuation_point,
+    size_t* assert_messages_count_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // XLS_PUBLIC_STANDALONE_AOT_RUNTIME_H_

--- a/xls/public/standalone_aot_runtime_test.cc
+++ b/xls/public/standalone_aot_runtime_test.cc
@@ -1,0 +1,138 @@
+// Copyright 2026 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/public/standalone_aot_runtime.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "xls/jit/generated_code_callback_abi.h"
+
+namespace {
+
+// Minimal generated-function stand-in that exercises the direct-call path and
+// one supported assertion callback.
+int64_t FakeAssertEntrypoint(const uint8_t* const* inputs,
+                             uint8_t* const* outputs, void* temp_buffer,
+                             xls::InterpreterEvents* events,
+                             xls::InstanceContext* instance_context,
+                             xls::JitRuntime* jit_runtime,
+                             int64_t continuation_point) {
+  outputs[0][0] = inputs[0][0] + 1;
+  auto* vtable = reinterpret_cast<xls::InstanceContextVTable*>(instance_context);
+  vtable->record_assertion(instance_context, "boom", events);
+  return 0;
+}
+
+// Minimal generated-function stand-in that checks the standalone heap callback
+// still honors over-aligned allocation requests.
+int64_t FakeAlignedAllocationEntrypoint(
+    const uint8_t* const* inputs, uint8_t* const* outputs, void* temp_buffer,
+    xls::InterpreterEvents* events, xls::InstanceContext* instance_context,
+    xls::JitRuntime* jit_runtime, int64_t continuation_point) {
+  auto* vtable = reinterpret_cast<xls::InstanceContextVTable*>(instance_context);
+  void* buffer = vtable->allocate_buffer(instance_context, /*byte_size=*/17,
+                                         /*alignment=*/64);
+  outputs[0][0] = reinterpret_cast<uintptr_t>(buffer) % 64 == 0 ? 1 : 0;
+  vtable->deallocate_buffer(instance_context, buffer);
+  return 0;
+}
+
+// Verifies: direct-call artifacts run and retain assertion messages.
+// Catches: regressions that disconnect the trampoline or assertion callback.
+TEST(XlsStandaloneAotRuntimeTest, RunsDirectFunctionAndCollectsAssertions) {
+  xls_standalone_aot_runtime* runtime = nullptr;
+  ASSERT_EQ(
+      xls_standalone_aot_runtime_create(
+          XLS_STANDALONE_AOT_ABI_VERSION,
+          XLS_STANDALONE_AOT_RUNTIME_FEATURE_ASSERTIONS, &runtime),
+      XLS_STANDALONE_AOT_RUNTIME_STATUS_OK);
+  ASSERT_NE(runtime, nullptr);
+
+  uint8_t input = 41;
+  uint8_t output = 0;
+  const uint8_t* inputs[1] = {&input};
+  uint8_t* outputs[1] = {&output};
+  uint8_t temp_buffer[1] = {0};
+  size_t assert_messages_count = 0;
+
+  EXPECT_EQ(xls_standalone_aot_entrypoint_trampoline(
+                reinterpret_cast<uintptr_t>(&FakeAssertEntrypoint), inputs,
+                outputs, temp_buffer, runtime, /*continuation_point=*/0,
+                &assert_messages_count),
+            0);
+  EXPECT_EQ(output, 42);
+  EXPECT_EQ(assert_messages_count, 1);
+  EXPECT_EQ(xls_standalone_aot_runtime_get_assert_message_count(runtime), 1);
+  EXPECT_EQ(
+      std::string{xls_standalone_aot_runtime_get_assert_message(runtime, 0)},
+      "boom");
+
+  xls_standalone_aot_runtime_clear_events(runtime);
+  EXPECT_EQ(xls_standalone_aot_runtime_get_assert_message_count(runtime), 0);
+  xls_standalone_aot_runtime_free(runtime);
+}
+
+// Verifies: generated-code heap allocations preserve requested alignment.
+// Catches: regressions that round size without honoring over-aligned requests.
+TEST(XlsStandaloneAotRuntimeTest, PreservesRequestedHeapAlignment) {
+  xls_standalone_aot_runtime* runtime = nullptr;
+  ASSERT_EQ(
+      xls_standalone_aot_runtime_create(XLS_STANDALONE_AOT_ABI_VERSION,
+                                        /*required_features=*/0, &runtime),
+      XLS_STANDALONE_AOT_RUNTIME_STATUS_OK);
+  ASSERT_NE(runtime, nullptr);
+
+  uint8_t input = 0;
+  uint8_t output = 0;
+  const uint8_t* inputs[1] = {&input};
+  uint8_t* outputs[1] = {&output};
+  uint8_t temp_buffer[1] = {0};
+  size_t assert_messages_count = 0;
+
+  EXPECT_EQ(
+      xls_standalone_aot_entrypoint_trampoline(
+          reinterpret_cast<uintptr_t>(&FakeAlignedAllocationEntrypoint), inputs,
+          outputs, temp_buffer, runtime, /*continuation_point=*/0,
+          &assert_messages_count),
+      0);
+  EXPECT_EQ(output, 1);
+  EXPECT_EQ(assert_messages_count, 0);
+
+  xls_standalone_aot_runtime_free(runtime);
+}
+
+// Negative test: validates error handling for unsupported trace requirements.
+TEST(XlsStandaloneAotRuntimeTest, RejectsFutureTraceRequirementForNow) {
+  xls_standalone_aot_runtime* runtime = nullptr;
+  EXPECT_EQ(xls_standalone_aot_runtime_create(
+                XLS_STANDALONE_AOT_ABI_VERSION,
+                XLS_STANDALONE_AOT_RUNTIME_FEATURE_TRACES, &runtime),
+            XLS_STANDALONE_AOT_RUNTIME_STATUS_UNSUPPORTED_FEATURE);
+  EXPECT_EQ(runtime, nullptr);
+}
+
+// Negative test: validates error handling for mismatched ABI versions.
+TEST(XlsStandaloneAotRuntimeTest, RejectsUnknownAbiVersion) {
+  xls_standalone_aot_runtime* runtime = nullptr;
+  EXPECT_EQ(xls_standalone_aot_runtime_create(
+                XLS_STANDALONE_AOT_ABI_VERSION + 1,
+                XLS_STANDALONE_AOT_RUNTIME_FEATURE_ASSERTIONS, &runtime),
+            XLS_STANDALONE_AOT_RUNTIME_STATUS_UNSUPPORTED_ABI_VERSION);
+  EXPECT_EQ(runtime, nullptr);
+}
+
+}  // namespace


### PR DESCRIPTION
Precompiled direct-call AOT artifacts now execute through an XLS-owned static runtime instead of relying on downstream code to mirror internal JIT/libxls callback layout. The change introduces a small public standalone runtime ABI, splits the generated-code callback contract away from the full JIT implementation, and preserves assertion reporting without requiring copied consumers to ship a `libxls` DSO.

# Problem Solved

Products that only execute already-compiled XLS modules should not need the full `libxls` runtime beside the final copied artifact.

Before this change, the generated AOT callback contract was effectively owned by the in-process JIT runtime. Downstream code that wanted to execute precompiled artifacts without the ordinary runtime stack had to mirror pieces of that C++ ABI outside XLS, including callback-table shape, assertion handling, and scratch allocation behavior. That makes the runtime boundary fragile: the code that defines the ABI and the code that reimplements it drift independently.

This PR moves that ownership back into XLS. It defines the standalone runtime contract in C++, ships it as a static archive, and keeps the generated-code ABI compatible with the ordinary JIT path while exposing only the smaller runtime surface that direct-call standalone artifacts actually need.

# Mental Model

Generated AOT code already expects to call into a callback table. Conceptually, an artifact can do something like:

```cpp
vtable->record_assertion(instance_context, "boom", events);
```

Previously, satisfying that call meant depending on the full JIT/libxls-side runtime shape, or reimplementing that shape elsewhere.

After this PR:

```cpp
xls_standalone_aot_runtime* runtime = nullptr;
xls_standalone_aot_runtime_create(
    XLS_STANDALONE_AOT_ABI_VERSION,
    XLS_STANDALONE_AOT_RUNTIME_FEATURE_ASSERTIONS,
    &runtime);

xls_standalone_aot_entrypoint_trampoline(
    function_ptr,
    inputs,
    outputs,
    temp_buffer,
    runtime,
    0,
    &assert_count);
```

The generated function still sees the ABI-compatible callback table it expects, but the host only links the focused standalone runtime archive. Assertions are retained and readable through the public API, while unsupported features are rejected up front or abort if somehow reached unexpectedly.

# What Changed

## 1. Add a public standalone runtime API

New public files:

- `xls/public/standalone_aot_runtime.h`
- `xls/public/standalone_aot_runtime.cc`

They define a small C ABI for function-only standalone AOT execution:

- runtime creation and destruction
- assertion-event clearing and lookup
- `xls_standalone_aot_entrypoint_trampoline(...)`

The runtime object owns:

- an ABI-compatible callback table for generated AOT code
- `InterpreterEvents` storage for assertion messages

The trampoline adapts a raw generated entrypoint pointer to that runtime object, invokes the artifact, and reports the post-call assertion count.

The first landing intentionally supports:

- direct-call AOT functions
- runtime assertions
- generated-code scratch allocation

It intentionally does not support yet:

- traces
- proc queues
- block bookkeeping
- observer callbacks

Those unsupported callback slots remain present in the table so the ABI layout stays stable, but they fail fast if reached. That preserves the generated-code contract without silently pretending the standalone runtime supports behavior it does not implement.

## 2. Split the generated-code callback ABI from the heavyweight JIT runtime

New file:

- `xls/jit/jit_callback_abi.h`

Refactored files:

- `xls/jit/jit_callbacks.h`
- `xls/jit/jit_callbacks.cc`

Before this PR, `jit_callbacks.h` owned both:

1. the binary callback-table layout that generated AOT code dereferences directly; and
2. the full in-process JIT execution state for proc/block support, type materialization, observers, and channel queues.

This PR separates those concerns.

`jit_callback_abi.h` now defines only the ABI-visible callback table:

- `InstanceContextVTable`
- the exact function pointer signatures
- the fixed 12-slot layout
- a `static_assert` that it remains a dense pointer array

`jit_callbacks.h` remains the ordinary full JIT context, but it now imports that ABI definition instead of declaring it inline. This lets the standalone runtime satisfy the same generated-code ABI without depending on the rest of the JIT implementation.

## 3. Share assertion and allocation callbacks between standalone AOT and full JIT

New files:

- `xls/jit/aot_runtime_callbacks.h`
- `xls/jit/aot_runtime_callbacks.cc`

These extract the callbacks that both runtime modes need:

- `RecordAssertion`
- `AllocateBuffer`
- `DeallocateBuffer`

The ordinary JIT runtime installs these shared callbacks into its callback table. The standalone runtime installs the same implementations into its lighter callback table.

That keeps the supported semantics unified:

- assertion callbacks produce the same event representation
- scratch allocation preserves the same alignment behavior
- downstream standalone execution does not grow a second implementation of those runtime details

## 4. Keep assertion-only event plumbing lightweight

Changed files:

- `xls/ir/events.h`
- `xls/ir/events.cc`

New file:

- `xls/ir/events_assertions.cc`

Assertion-specific `InterpreterEvents` behavior moves into a dedicated translation unit:

- `AddAssertMessage`
- `GetAssertMessages`

The PR also adds:

- `GetAssertMessageCount`
- `GetAssertMessage(index)`

Those accessors back the public standalone runtime API without inventing a second event model.

The important design point is that standalone AOT keeps using `InterpreterEvents`, but assertion-only users no longer have to pull in the heavier trace-formatting implementation path just to retain and read assertion messages.

# Architecture

The resulting runtime split is:

- full JIT path:
  - keeps the complete `InstanceContext`
  - supports the broader callback surface
  - continues to own heavyweight runtime state

- standalone AOT path:
  - links a focused XLS-owned static archive
  - uses the same generated-code callback ABI
  - supports only the first-landing contract for copied direct-call artifacts
  - records assertions through the canonical XLS event model

That distinction is the main design choice in this PR. It is not trying to make all of `libxls` statically linkable as one monolith. It creates a narrower LLVM-free standalone runtime surface for the deployment case that only executes already-compiled modules.

# Non-goals

This PR does not:

- make every libxls/JIT feature available in standalone form
- add standalone trace support yet
- add proc or block execution support to the standalone runtime
- define the final long-term compatibility policy beyond the current ABI version check and same-generation expectation

The public API reserves an explicit trace feature bit so a later trace-capable runtime can extend the contract intentionally rather than requiring another ownership redesign.

# Tradeoffs

The key tradeoff is explicit narrowness.

The standalone runtime duplicates the ABI table shape, but not the full JIT runtime. Unsupported callbacks are left visible and fail loudly instead of being omitted, because generated code indexes that table by fixed slot layout. That keeps the ABI honest while preventing a broad accidental expansion of the first landing.

The archive also reuses `InterpreterEvents` for assertions instead of creating a standalone-only message container. That keeps behavior aligned with the existing XLS event model, even though the standalone public API exposes only the small assertion-facing slice it needs today.

# Validation

Validation covered the standalone runtime contract, callback behavior, and static archive integration:

- `bazel test --cxxopt=-std=c++20 --host_cxxopt=-std=c++20 //xls/public:standalone_aot_runtime_test`
- `bazel build --cxxopt=-std=c++20 --host_cxxopt=-std=c++20 //xls/public:xls_aot_runtime`

The focused runtime test verifies:

- direct-call execution through the standalone trampoline
- assertion capture and readback
- reuse after clearing recorded events
- preservation of requested heap alignment for generated-code scratch allocation
- rejection of unsupported trace requirements
- rejection of unknown ABI versions

Archive inspection also confirmed the standalone runtime archive stays within the intended lightweight boundary for the validated build shape:

- `nm -u bazel-bin/xls/public/libxls_aot_runtime.a`

The same focused standalone runtime/archive proof was exercised on both macOS and Ubuntu during the broader rollout validation.

# Landing Order

This is the producer PR for the multi-repository rollout.

Downstream PRs consume the released standalone runtime archive after this lands:

- `rules_xlsynth` exposes the archive through the bundle surface
- `xlsynth-crate` links standalone wrappers against it
- downstream consumer repinning happens last once the final producer chain is selected

<!-- spr-stack:start -->
**Stack**:
-   #10
-   #9
- ➡ #8

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->
