### PR TITLE
aot: publish the standalone runtime static-link contract

### DIFF
--- a/.github/workflows/build-and-release-dylib.yml
+++ b/.github/workflows/build-and-release-dylib.yml
@@ -70,6 +70,8 @@ jobs:
         # dylib payload copied beside executables.
         cp bazel-bin/xls/public/libxls_aot_runtime.a osx-artifacts-arm64/libxls_aot_runtime-arm64.a
         shasum -a 256 osx-artifacts-arm64/libxls_aot_runtime-arm64.a > osx-artifacts-arm64/libxls_aot_runtime-arm64.a.sha256
+        cp xls/public/libxls_aot_runtime_link.toml osx-artifacts-arm64/libxls_aot_runtime_link-arm64.toml
+        shasum -a 256 osx-artifacts-arm64/libxls_aot_runtime_link-arm64.toml > osx-artifacts-arm64/libxls_aot_runtime_link-arm64.toml.sha256
 
         cp bazel-bin/xls/dslx/interpreter_main              osx-artifacts-arm64/dslx_interpreter_main-arm64
         shasum -a 256 osx-artifacts-arm64/dslx_interpreter_main-arm64 > osx-artifacts-arm64/dslx_interpreter_main-arm64.sha256
@@ -198,6 +200,8 @@ jobs:
         # DSO payload copied beside executables.
         cp bazel-bin/xls/public/libxls_aot_runtime.a rocky8-artifacts/libxls_aot_runtime-rocky8.a
         sha256sum rocky8-artifacts/libxls_aot_runtime-rocky8.a > rocky8-artifacts/libxls_aot_runtime-rocky8.a.sha256
+        cp xls/public/libxls_aot_runtime_link.toml rocky8-artifacts/libxls_aot_runtime_link-rocky8.toml
+        sha256sum rocky8-artifacts/libxls_aot_runtime_link-rocky8.toml > rocky8-artifacts/libxls_aot_runtime_link-rocky8.toml.sha256
         python3 dist/package_runtime_closure.py --libxls bazel-bin/xls/public/libxls.so --output-dir rocky8-artifacts --release-target rocky8
         sha256sum rocky8-artifacts/libxls-runtime-rocky8.tar.gz > rocky8-artifacts/libxls-runtime-rocky8.tar.gz.sha256
         sha256sum rocky8-artifacts/libxls-runtime-rocky8-manifest.json > rocky8-artifacts/libxls-runtime-rocky8-manifest.json.sha256
@@ -361,6 +365,8 @@ jobs:
         # DSO payload copied beside executables.
         cp bazel-bin/xls/public/libxls_aot_runtime.a ubuntu2004-artifacts/libxls_aot_runtime-ubuntu2004.a
         sha256sum ubuntu2004-artifacts/libxls_aot_runtime-ubuntu2004.a > ubuntu2004-artifacts/libxls_aot_runtime-ubuntu2004.a.sha256
+        cp xls/public/libxls_aot_runtime_link.toml ubuntu2004-artifacts/libxls_aot_runtime_link-ubuntu2004.toml
+        sha256sum ubuntu2004-artifacts/libxls_aot_runtime_link-ubuntu2004.toml > ubuntu2004-artifacts/libxls_aot_runtime_link-ubuntu2004.toml.sha256
         python3 dist/package_runtime_closure.py --libxls bazel-bin/xls/public/libxls.so --output-dir ubuntu2004-artifacts --release-target ubuntu2004
         sha256sum ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz > ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz.sha256
         sha256sum ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json > ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json.sha256
@@ -465,6 +471,8 @@ jobs:
           osx-artifacts-arm64/libxls-arm64.dylib.sha256 \
           osx-artifacts-arm64/libxls_aot_runtime-arm64.a \
           osx-artifacts-arm64/libxls_aot_runtime-arm64.a.sha256 \
+          osx-artifacts-arm64/libxls_aot_runtime_link-arm64.toml \
+          osx-artifacts-arm64/libxls_aot_runtime_link-arm64.toml.sha256 \
           osx-artifacts-arm64/dslx_interpreter_main-arm64 \
           osx-artifacts-arm64/dslx_interpreter_main-arm64.sha256 \
           osx-artifacts-arm64/dslx_ls-arm64 \
@@ -496,6 +504,8 @@ jobs:
           ubuntu2004-artifacts/libxls-ubuntu2004.so.sha256 \
           ubuntu2004-artifacts/libxls_aot_runtime-ubuntu2004.a \
           ubuntu2004-artifacts/libxls_aot_runtime-ubuntu2004.a.sha256 \
+          ubuntu2004-artifacts/libxls_aot_runtime_link-ubuntu2004.toml \
+          ubuntu2004-artifacts/libxls_aot_runtime_link-ubuntu2004.toml.sha256 \
           ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz \
           ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz.sha256 \
           ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json \
@@ -529,6 +539,8 @@ jobs:
           rocky8-artifacts/libxls-rocky8.so.sha256 \
           rocky8-artifacts/libxls_aot_runtime-rocky8.a \
           rocky8-artifacts/libxls_aot_runtime-rocky8.a.sha256 \
+          rocky8-artifacts/libxls_aot_runtime_link-rocky8.toml \
+          rocky8-artifacts/libxls_aot_runtime_link-rocky8.toml.sha256 \
           rocky8-artifacts/libxls-runtime-rocky8.tar.gz \
           rocky8-artifacts/libxls-runtime-rocky8.tar.gz.sha256 \
           rocky8-artifacts/libxls-runtime-rocky8-manifest.json \

--- a/make_local_release.py
+++ b/make_local_release.py
@@ -41,6 +41,7 @@ COMMON_TARGETS = [
 # runtime `libxls` DSO dependency.
 STATIC_AOT_RUNTIME_TARGET = "//xls/public:xls_aot_runtime"
 STATIC_AOT_RUNTIME_ARCHIVE = "bazel-bin/xls/public/libxls_aot_runtime.a"
+STATIC_AOT_RUNTIME_LINK_CONFIG = "xls/public/libxls_aot_runtime_link.toml"
 
 LINUX_TARGETS = COMMON_TARGETS + ["//xls/public:libxls.so"]
 MACOS_TARGETS = COMMON_TARGETS + ["//xls/public:libxls.dylib"]
@@ -230,14 +231,28 @@ def make_local_release(
             print(f"Permission denied while copying {binary_path}: {e}")
             sys.exit(1)
 
-    # Keep one stable archive name in local releases so downstream packagers do
-    # not need to infer it from the requested DSO target or host platform.
+    # Keep stable artifact names in local releases so downstream packagers do
+    # not need to infer them from the requested DSO target or host platform.
     static_aot_runtime_dest = os.path.join(output_dir, "libxls_aot_runtime.a")
+    static_aot_runtime_link_config_dest = os.path.join(
+        output_dir,
+        "libxls_aot_runtime_link.toml",
+    )
     try:
         shutil.copy2(STATIC_AOT_RUNTIME_ARCHIVE, static_aot_runtime_dest)
         print(f"Copied {STATIC_AOT_RUNTIME_ARCHIVE} to {static_aot_runtime_dest}")
+        shutil.copy2(
+            STATIC_AOT_RUNTIME_LINK_CONFIG,
+            static_aot_runtime_link_config_dest,
+        )
+        print(
+            "Copied {} to {}".format(
+                STATIC_AOT_RUNTIME_LINK_CONFIG,
+                static_aot_runtime_link_config_dest,
+            )
+        )
     except (FileNotFoundError, PermissionError) as e:
-        print(f"Failed to copy standalone AOT runtime archive: {e}")
+        print(f"Failed to copy standalone AOT runtime artifacts: {e}")
         sys.exit(1)
 
     if "//xls/public:libxls.so" in targets:

--- a/xls/public/libxls_aot_runtime_link.toml
+++ b/xls/public/libxls_aot_runtime_link.toml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Link-time requirements for binaries that consume libxls_aot_runtime.a.
+#
+# These are host-system libraries and frameworks required after the XLS runtime
+# closure has been flattened into the static archive. They are not runtime
+# sidecar artifacts shipped beside copied executables.
+format_version = 1
+
+[targets.macos]
+system_libraries = ["c++"]
+frameworks = ["CoreFoundation"]
+
+[targets.linux]
+system_libraries = ["c++", "c++abi", "unwind", "pthread", "dl"]
+frameworks = []


### PR DESCRIPTION
Publish a producer-owned link manifest beside `libxls_aot_runtime.a` and include it in both local and released XLS artifact outputs. Without that manifest, downstream packagers must independently reconstruct the final-link contract for the archive: Linux consumers need `c++`, `c++abi`, `unwind`, `pthread`, and `dl`, while macOS consumers need `c++` plus the `CoreFoundation` framework. Keeping those requirements beside the archive makes the standalone runtime artifact self-describing instead of pushing producer knowledge into every consumer.

# Problem Solved
The standalone runtime archive from the lower PR gives precompiled AOT consumers a static runtime artifact, but the archive still has host-system link requirements that are not discoverable from the `.a` file alone. If XLS does not publish those requirements, every downstream packager must carry and maintain its own platform table: Linux needs `c++`, `c++abi`, `unwind`, `pthread`, and `dl`; macOS needs `c++` and `CoreFoundation`. That duplicates producer-owned knowledge in consumers and can drift when the runtime closure changes.

# Mental model
Treat the two files as one producer contract:

- `libxls_aot_runtime.a` - runtime implementation to link into the final binary
- `libxls_aot_runtime_link.toml` - producer-authored link recipe for that archive

The manifest records host-system libraries and frameworks required at final link time. It is not a runtime sidecar payload shipped beside copied executables.

# What changed
- Add `xls/public/libxls_aot_runtime_link.toml` with macOS and Linux static-link requirements.
- Make `make_local_release.py` copy the archive and manifest under stable local-release names.
- Extend the release workflow to publish platform-suffixed manifest artifacts and SHA256 files beside each standalone runtime archive.

# Non-goals
- This PR does not change the standalone runtime ABI or generated-wrapper behavior.
- This PR does not teach bundle or Rust consumers to read the manifest; that happens in the dependent `rules_xlsynth` and `xlsynth-crate` follow-ons.
- This PR does not change runtime-feature admission metadata.

# Tradeoffs
Keeping the link contract in a separate manifest adds one artifact to the release payload, but it keeps native link requirements explicit, reviewable, and transportable with the archive. That is better than silently encoding the same platform knowledge in every consumer.

# Architecture
This is the producer half of the archive-plus-manifest handoff. Release outputs now carry a self-describing pair, and downstream layers can move that pair intact rather than inferring linker requirements from repository-local conditionals.

# Observability
Release directories now make the contract visible: a reviewer or downstream packager can see the archive, its manifest, and checksums for both in the same artifact set. That gives the next layer a concrete producer artifact to validate and consume.

# Tests
Validation for this PR is the producer packaging surface itself:

- local release generation now copies both the archive and `libxls_aot_runtime_link.toml`
- release artifact assembly now emits platform-specific manifest artifacts plus SHA256 sidecars alongside the archive

The dependent bundle and Rust consumer PRs validate transport and consumption of that producer-owned link contract.

<!-- spr-stack:start -->
**Stack**:
-   #10
- ➡ #9

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->
