### PR TITLE
jit: publish standalone runtime feature requirements

### DIFF
--- a/xls/jit/aot_entrypoint.cc
+++ b/xls/jit/aot_entrypoint.cc
@@ -16,6 +16,7 @@
 
 #include "xls/common/status/ret_check.h"
 #include "xls/dev_tools/extract_interface.h"
+#include "xls/ir/call_graph.h"
 #include "xls/ir/function.h"
 #include "xls/ir/function_base.h"
 #include "xls/ir/nodes.h"
@@ -24,6 +25,50 @@
 #include "xls/jit/llvm_type_converter.h"
 
 namespace xls {
+namespace {
+
+void PopulateStandaloneRuntimeFeatureRequirements(
+    FunctionBase* function_base, AotEntrypointProto* proto) {
+  bool has_assertions = false;
+  bool has_traces = false;
+  bool has_covers = false;
+
+  for (FunctionBase* dependency :
+       GetDependentFunctions(function_base, /*include_procs=*/true)) {
+    for (Node* node : dependency->nodes()) {
+      switch (node->op()) {
+        case Op::kAssert:
+          has_assertions = true;
+          break;
+        case Op::kTrace:
+          has_traces = true;
+          break;
+        case Op::kCover:
+          has_covers = true;
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  AotRuntimeFeatureRequirementsProto* requirements =
+      proto->mutable_standalone_runtime_feature_requirements();
+  if (has_assertions) {
+    requirements->add_required_feature(
+        AotRuntimeFeatureRequirementsProto::ASSERTIONS);
+  }
+  if (has_traces) {
+    requirements->add_required_feature(
+        AotRuntimeFeatureRequirementsProto::TRACES);
+  }
+  if (has_covers) {
+    requirements->add_required_feature(
+        AotRuntimeFeatureRequirementsProto::COVERS);
+  }
+}
+
+}  // namespace
 
 absl::StatusOr<AotEntrypointProto> GenerateAotEntrypointProto(
     Package* package, const FunctionEntrypoint& entrypoint, bool include_msan,
@@ -122,6 +167,7 @@ absl::StatusOr<AotEntrypointProto> GenerateAotEntrypointProto(
 
   proto.set_temp_buffer_size(object_code.temp_buffer_size());
   proto.set_temp_buffer_alignment(object_code.temp_buffer_alignment());
+  PopulateStandaloneRuntimeFeatureRequirements(func, &proto);
   return proto;
 }
 

--- a/xls/jit/aot_entrypoint.proto
+++ b/xls/jit/aot_entrypoint.proto
@@ -20,6 +20,19 @@ import "xls/ir/xls_ir_interface.proto";
 import "xls/ir/xls_type.proto";
 import "xls/jit/type_layout.proto";
 
+// Runtime features that a standalone AOT consumer must be prepared to service
+// when invoking one XLS-produced entrypoint.
+message AotRuntimeFeatureRequirementsProto {
+  enum Feature {
+    INVALID = 0;
+    ASSERTIONS = 1;
+    TRACES = 2;
+    COVERS = 3;
+  }
+
+  repeated Feature required_feature = 1;
+}
+
 // Proto version of the jittedFunctionBase information needed to call a AOTd
 // function.
 message AotEntrypointProto {
@@ -103,6 +116,13 @@ message AotEntrypointProto {
   optional TypeLayoutsProto outputs_layout = 19;
   repeated string inputs_names = 20;
   repeated string outputs_names = 21;
+
+  // Presence is semantic: newer XLS producers always emit this envelope, even
+  // when no standalone runtime features are required. Consumers can therefore
+  // distinguish "new producer, empty requirements" from "older producer that
+  // predates runtime-feature metadata".
+  optional AotRuntimeFeatureRequirementsProto
+      standalone_runtime_feature_requirements = 26;
 }
 
 // A single object file can have entrypoints for many different targets. This is

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -52,6 +52,7 @@
 
 namespace {
 
+using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 
 // Smoke test for `xls_convert_dslx_to_ir` C API.
@@ -2381,6 +2382,12 @@ top fn add_one(tok: token, x: bits[32]) -> bits[32] {
 TEST(XlsCApiTest, AotCompileFunction) {
   const std::string_view kIr = R"(package my_package
 
+fn noisy_sibling(tok: token, x: bits[32]) -> bits[32] {
+  always_on: bits[1] = literal(value=1)
+  traced_tok: token = trace(tok, always_on, format="x: {}", data_operands=[x])
+  ret out: bits[32] = identity(x)
+}
+
 top fn add_one(x: bits[32]) -> bits[32] {
   one: bits[32] = literal(value=1)
   ret result: bits[32] = add(x, one)
@@ -2420,6 +2427,69 @@ top fn add_one(x: bits[32]) -> bits[32] {
             xls::AotEntrypointProto::FUNCTION);
   EXPECT_TRUE(entrypoints.entrypoint(0).has_function_symbol());
   EXPECT_TRUE(entrypoints.entrypoint(0).has_packed_function_symbol());
+  ASSERT_TRUE(entrypoints.entrypoint(0)
+                  .has_standalone_runtime_feature_requirements());
+  EXPECT_EQ(entrypoints.entrypoint(0)
+                .standalone_runtime_feature_requirements()
+                .required_feature_size(),
+            0);
+}
+
+TEST(XlsCApiTest, AotCompileFunctionRecordsStandaloneRuntimeFeatures) {
+  const std::string_view kIr = R"(package feature_pkg
+
+fn featureful(tok: token, pred: bits[1], x: bits[8]) -> bits[8] {
+  asserted_tok: token = assert(tok, pred, message="pred must hold")
+  always_on: bits[1] = literal(value=1)
+  traced_tok: token = trace(asserted_tok, always_on, format="x: {}", data_operands=[x])
+  covered: () = cover(pred, label="pred_is_one")
+  ret out: bits[8] = identity(x)
+}
+
+top fn calls_featureful(tok: token, pred: bits[1], x: bits[8]) -> bits[8] {
+  ret out: bits[8] = invoke(tok, pred, x, to_apply=featureful)
+}
+)";
+
+  char* error = nullptr;
+  xls_package* package = nullptr;
+  ASSERT_TRUE(xls_parse_ir_package(kIr.data(), "test.ir", &error, &package))
+      << "error: " << error;
+  ASSERT_NE(package, nullptr);
+  absl::Cleanup free_package([=] { xls_package_free(package); });
+
+  xls_function* function = nullptr;
+  ASSERT_TRUE(
+      xls_package_get_function(package, "calls_featureful", &error, &function));
+  ASSERT_NE(function, nullptr);
+
+  uint8_t* object_bytes = nullptr;
+  size_t object_byte_count = 0;
+  uint8_t* proto_bytes = nullptr;
+  size_t proto_byte_count = 0;
+  ASSERT_TRUE(xls_aot_compile_function(function, &error, &object_bytes,
+                                       &object_byte_count, &proto_bytes,
+                                       &proto_byte_count))
+      << "error: " << error;
+  ASSERT_GT(object_byte_count, 0);
+  absl::Cleanup free_object_bytes(
+      [=] { xls_aot_object_code_free(object_bytes); });
+  ASSERT_GT(proto_byte_count, 0);
+  absl::Cleanup free_proto_bytes(
+      [=] { xls_aot_entrypoints_proto_free(proto_bytes); });
+
+  xls::AotPackageEntrypointsProto entrypoints;
+  ASSERT_TRUE(entrypoints.ParseFromArray(proto_bytes, proto_byte_count));
+  ASSERT_EQ(entrypoints.entrypoint_size(), 1);
+  ASSERT_TRUE(entrypoints.entrypoint(0)
+                  .has_standalone_runtime_feature_requirements());
+  EXPECT_THAT(entrypoints.entrypoint(0)
+                  .standalone_runtime_feature_requirements()
+                  .required_feature(),
+              ElementsAre(
+                  xls::AotRuntimeFeatureRequirementsProto::ASSERTIONS,
+                  xls::AotRuntimeFeatureRequirementsProto::TRACES,
+                  xls::AotRuntimeFeatureRequirementsProto::COVERS));
 }
 
 TEST(XlsCApiTest, AotEntrypointTrampoline) {


### PR DESCRIPTION
Publish XLS-authored standalone runtime feature requirements for AOT entrypoints.

- Rust stops re-parsing IR to discover whether an entrypoint needs assertions, traces, or covers.
- Rust reads the XLS-authored requirements from the emitted entrypoint metadata instead.
- If the entrypoint requires traces or covers, standalone AOT generation rejects it today because that runtime path does not support them yet.
- If it requires assertions, Rust can keep going and pass the corresponding runtime feature bit through.

The public C API tests cover clean entrypoints plus reachable assertion, trace, and cover requirements.

<!-- spr-stack:start -->
**Stack**:
- ➡ #10

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->