### PR TITLE
dslx: prevent specialized spans from overlapping real source

### DIFF
--- a/xls/dslx/frontend/function_specializer.cc
+++ b/xls/dslx/frontend/function_specializer.cc
@@ -51,14 +51,12 @@ class SyntheticSpanAllocator {
       : module_(module),
         file_table_(module != nullptr ? module->file_table() : nullptr) {
     if (file_table_ != nullptr) {
-      if (module_ != nullptr && module_->fs_path().has_value()) {
-        synthetic_file_ =
-            file_table_->GetOrCreate(module_->fs_path()->generic_string());
-      } else {
-        synthetic_file_ = file_table_->GetOrCreate(absl::StrFormat(
-            "<specialization:%s:%s@%p>", module_->name(), specialized_name,
-            static_cast<const void*>(source_function)));
-      }
+      // Synthetic line/column coordinates must not share a file identity with
+      // real source text, or fabricated spans can appear to contain unrelated
+      // real invocations.
+      synthetic_file_ = file_table_->GetOrCreate(absl::StrFormat(
+          "<specialization:%s:%s@%p>", module_->name(), specialized_name,
+          static_cast<const void*>(source_function)));
     }
   }
 

--- a/xls/dslx/frontend/function_specializer_test.cc
+++ b/xls/dslx/frontend/function_specializer_test.cc
@@ -196,12 +196,8 @@ fn twice<N: u32>(x: bits[N]) -> bits[N] {
   std::string_view specialized_filename =
       specialized->span().GetFilename(files);
 
-  if (module->fs_path().has_value()) {
-    EXPECT_EQ(specialized_filename, module->fs_path()->generic_string());
-  } else {
-    EXPECT_NE(original_filename, specialized_filename);
-    EXPECT_TRUE(absl::StrContains(specialized_filename, "<specialization:"));
-  }
+  EXPECT_NE(original_filename, specialized_filename);
+  EXPECT_TRUE(absl::StrContains(specialized_filename, "<specialization:"));
 
   // The specialized function span should enclose its body span.
   ASSERT_NE(specialized->body(), nullptr);
@@ -377,6 +373,63 @@ fn select_poly<N: u32>(polys: uN[6][N], selector: uN[N]) -> uN[6] {
   absl::StatusOr<TypecheckedModule> replaced = ReplaceInvocationsInModule(
       retyped, absl::MakeSpan(callers_arr), absl::MakeSpan(rules_arr),
       *rewrite_import_data, "rewrite_test.rewrite");
+  ASSERT_TRUE(replaced.ok()) << replaced.status();
+}
+
+TEST(FunctionSpecializerTest,
+     SyntheticSpecializedCallerDoesNotOverlapRealInvocationSpans) {
+  constexpr std::string_view kProgram =
+      R"(fn helper(x: u32) -> u32 { x }
+
+fn unrelated(x: u32) -> u32 { helper(x) }
+
+fn id<N: u32>(x: bits[N]) -> bits[N] { x }
+)";
+
+  std::unique_ptr<ImportData> import_data = CreateImportDataPtrForTest();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      TypecheckedModule typechecked,
+      ParseAndTypecheck(kProgram, "synthetic_overlap_test.x",
+                        "synthetic_overlap_test", import_data.get()));
+
+  Module* module = typechecked.module;
+  ASSERT_NE(module, nullptr);
+
+  Function* id_fn = module->GetFunctionByName().at("id");
+  const ParametricBinding* binding = id_fn->parametric_bindings().front();
+  absl::flat_hash_map<std::string, InterpValue> env_bindings;
+  env_bindings.emplace(binding->identifier(),
+                       InterpValue::MakeUBits(/*bit_count=*/32, 32));
+  ParametricEnv env(env_bindings);
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Function * specialized,
+      InsertFunctionSpecialization(id_fn, env, "id_N32"));
+  ASSERT_NE(specialized, nullptr);
+
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Module> cloned_module,
+                           CloneModule(*module));
+  std::unique_ptr<ImportData> rewrite_import_data =
+      CreateImportDataPtrForTest();
+  rewrite_import_data->file_table() = *module->file_table();
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      TypecheckedModule retyped,
+      TypecheckModule(std::move(cloned_module), "synthetic_overlap_test.x",
+                      rewrite_import_data.get()));
+
+  const Function* caller = retyped.module->GetFunction("id_N32").value();
+  const Function* callee = retyped.module->GetFunction("helper").value();
+  const Function* callers_arr[] = {caller};
+
+  InvocationRewriteRule rule;
+  rule.from_callee = callee;
+  rule.to_callee = callee;
+  const InvocationRewriteRule rules_arr[] = {rule};
+
+  absl::StatusOr<TypecheckedModule> replaced = ReplaceInvocationsInModule(
+      retyped, absl::MakeSpan(callers_arr), absl::MakeSpan(rules_arr),
+      *rewrite_import_data, "synthetic_overlap_test.rewrite");
   ASSERT_TRUE(replaced.ok()) << replaced.status();
 }
 

--- a/xls/dslx/type_system_v2/inference_table_utils.cc
+++ b/xls/dslx/type_system_v2/inference_table_utils.cc
@@ -26,6 +26,7 @@
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/match.h"
 #include "absl/strings/substitute.h"
 #include "xls/common/status/ret_check.h"
 #include "xls/common/status/status_macros.h"
@@ -56,18 +57,22 @@ absl::StatusOr<Number*> MakeTypeCheckedNumber(
     Module& module, InferenceTable& table, const Span& span,
     const InterpValue& value, const TypeAnnotation* type_annotation) {
   // Invariant: nodes created into `module` should either have a "no-file" span
-  // (for internally-fabricated nodes) or a span that points at `module`'s own
-  // source file. Violating this makes downstream consumers that resolve nodes
-  // by (kind, span) fragile and can lead to confusing "could not find node"
-  // errors.
+  // (for internally-fabricated nodes), a recognized internal synthetic file,
+  // or a span that points at `module`'s own source file. Violating this makes
+  // downstream consumers that resolve nodes by (kind, span) fragile and can
+  // lead to confusing "could not find node" errors.
   //
   // Note: not all modules have a filesystem path (e.g. in-memory modules); we
   // only enforce this when `fs_path()` is known.
   XLS_RET_CHECK(module.file_table() != nullptr);
   if (span.HasFile() && module.fs_path().has_value()) {
     std::string_view span_filename = span.GetFilename(*module.file_table());
-    XLS_RET_CHECK_EQ(span_filename, module.fs_path()->generic_string())
-        << "MakeTypeCheckedNumber span filename must match module fs_path; "
+    const bool is_specialization_span =
+        absl::StartsWith(span_filename, "<specialization:");
+    XLS_RET_CHECK(is_specialization_span ||
+                  span_filename == module.fs_path()->generic_string())
+        << "MakeTypeCheckedNumber span filename must match module fs_path or "
+           "use a recognized specialization pseudo-file; "
         << "module name: `" << module.name() << "`; "
         << "span: `" << span.ToString(*module.file_table()) << "`; "
         << "module fs_path: `" << module.fs_path()->generic_string() << "`";


### PR DESCRIPTION
This keeps fabricated specialization spans separate from real DSLX source spans. Specialized functions now live in their own synthetic source file identity, so invocation replacement no longer confuses unrelated real calls with nodes inside a synthesized function.

# Problem Solved

`InsertFunctionSpecialization()` was fabricating spans with synthetic line numbers but, for file-backed modules, reusing the real module filename. That allowed a specialized function's span to overlap unrelated source text in the same file.

During `ReplaceInvocationsInModule()`, that overlap could make `ContainedWithinFunction()` see:

- the AST parent chain says an invocation is outside the candidate caller
- the source span says it is inside

The mismatch trips the containment check and aborts the rewrite.

Minimized example:

```dslx
fn helper(x: u32) -> u32 { x }
fn unrelated(x: u32) -> u32 { helper(x) }
fn id<N: u32>(x: bits[N]) -> bits[N] { x }
```

After specializing `id`, the real `helper(x)` call in `unrelated` must never look like it belongs to the synthesized specialized function.

# What Changed

- `xls/dslx/frontend/function_specializer.cc`
  - Always assigns specialized functions a dedicated `<specialization:...>` pseudo-file instead of reusing the real DSLX source filename.
- `xls/dslx/type_system_v2/inference_table_utils.cc`
  - Accepts those specialization pseudo-files when rebuilding typechecked numeric values, so specialized modules still re-typecheck correctly.
- `xls/dslx/frontend/function_specializer_test.cc`
  - Updates the span expectation to require source-file separation.
  - Adds a regression test for the former containment-abort shape.

# Validation

- `bazel test //xls/dslx/frontend:function_specializer_test --test_output=errors`
- The same target also passed on Ubuntu 24, matching the environment where the original abort was reproduced.
