### PR TITLE
runtime: publish standalone AOT runtime sources for Bazel links

### DIFF
--- a/.github/workflows/build-and-release-dylib.yml
+++ b/.github/workflows/build-and-release-dylib.yml
@@ -175,6 +175,7 @@ jobs:
           //xls/public:libxls.so \
           //xls/public:c_api \
           //xls/public:xls_aot_runtime \
+          //xls/public:standalone_aot_runtime_source_archive \
           //xls/dslx:interpreter_main \
           //xls/dslx/lsp:dslx_ls \
           //xls/tools:opt_main \
@@ -367,6 +368,8 @@ jobs:
         sha256sum ubuntu2004-artifacts/libxls_aot_runtime-ubuntu2004.a > ubuntu2004-artifacts/libxls_aot_runtime-ubuntu2004.a.sha256
         cp xls/public/libxls_aot_runtime_link.toml ubuntu2004-artifacts/libxls_aot_runtime_link-ubuntu2004.toml
         sha256sum ubuntu2004-artifacts/libxls_aot_runtime_link-ubuntu2004.toml > ubuntu2004-artifacts/libxls_aot_runtime_link-ubuntu2004.toml.sha256
+        cp bazel-bin/xls/public/xls-aot-runtime-source.tar.gz ubuntu2004-artifacts/xls-aot-runtime-source.tar.gz
+        sha256sum ubuntu2004-artifacts/xls-aot-runtime-source.tar.gz > ubuntu2004-artifacts/xls-aot-runtime-source.tar.gz.sha256
         python3 dist/package_runtime_closure.py --libxls bazel-bin/xls/public/libxls.so --output-dir ubuntu2004-artifacts --release-target ubuntu2004
         sha256sum ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz > ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz.sha256
         sha256sum ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json > ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json.sha256
@@ -506,6 +509,8 @@ jobs:
           ubuntu2004-artifacts/libxls_aot_runtime-ubuntu2004.a.sha256 \
           ubuntu2004-artifacts/libxls_aot_runtime_link-ubuntu2004.toml \
           ubuntu2004-artifacts/libxls_aot_runtime_link-ubuntu2004.toml.sha256 \
+          ubuntu2004-artifacts/xls-aot-runtime-source.tar.gz \
+          ubuntu2004-artifacts/xls-aot-runtime-source.tar.gz.sha256 \
           ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz \
           ubuntu2004-artifacts/libxls-runtime-ubuntu2004.tar.gz.sha256 \
           ubuntu2004-artifacts/libxls-runtime-ubuntu2004-manifest.json \

--- a/make_local_release.py
+++ b/make_local_release.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
+import hashlib
 import os
+import re
 import shutil
 import subprocess
 import sys
-import glob
-import re
 
 import release_runtime_closure
 
@@ -42,6 +43,8 @@ COMMON_TARGETS = [
 STATIC_AOT_RUNTIME_TARGET = "//xls/public:xls_aot_runtime"
 STATIC_AOT_RUNTIME_ARCHIVE = "bazel-bin/xls/public/libxls_aot_runtime.a"
 STATIC_AOT_RUNTIME_LINK_CONFIG = "xls/public/libxls_aot_runtime_link.toml"
+STATIC_AOT_RUNTIME_SOURCE_TARGET = "//xls/public:standalone_aot_runtime_source_archive"
+STATIC_AOT_RUNTIME_SOURCE_ARCHIVE = "bazel-bin/xls/public/xls-aot-runtime-source.tar.gz"
 
 LINUX_TARGETS = COMMON_TARGETS + ["//xls/public:libxls.so"]
 MACOS_TARGETS = COMMON_TARGETS + ["//xls/public:libxls.dylib"]
@@ -123,6 +126,17 @@ def copy_flattened_protos(output_dir, root_proto):
             dst.write(content)
         print(f"Copied {proto_path} to {destination}")
 
+
+def write_sha256sum(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as artifact:
+        for chunk in iter(lambda: artifact.read(1024 * 1024), b""):
+            digest.update(chunk)
+    checksum_path = "{}.sha256".format(path)
+    with open(checksum_path, "w", encoding="utf-8") as checksum_file:
+        checksum_file.write("{}  {}\n".format(digest.hexdigest(), os.path.basename(path)))
+    return checksum_path
+
 # Function to get the current git hash and cleanliness status
 def get_git_info():
     try:
@@ -144,7 +158,7 @@ def make_local_release(
     release_target=None,
     allow_release_target_mismatch=False,
 ):
-    """Builds a local release bundle including the standalone AOT archive."""
+    """Builds a local release bundle including standalone AOT artifacts."""
     # Ensure the output directory exists and is writable
     if os.path.exists(output_dir):
         try:
@@ -156,7 +170,10 @@ def make_local_release(
 
     # Build the requested tool payload plus the standalone runtime archive that
     # downstream AOT consumers need at link time.
-    build_targets = targets + [STATIC_AOT_RUNTIME_TARGET]
+    build_targets = targets + [
+        STATIC_AOT_RUNTIME_TARGET,
+        STATIC_AOT_RUNTIME_SOURCE_TARGET,
+    ]
     if mode == "dbg-asan":
         build_command = [
             "bazel", "build", "-c", "dbg", "--config=asan"
@@ -238,6 +255,10 @@ def make_local_release(
         output_dir,
         "libxls_aot_runtime_link.toml",
     )
+    static_aot_runtime_source_dest = os.path.join(
+        output_dir,
+        "xls-aot-runtime-source.tar.gz",
+    )
     try:
         shutil.copy2(STATIC_AOT_RUNTIME_ARCHIVE, static_aot_runtime_dest)
         print(f"Copied {STATIC_AOT_RUNTIME_ARCHIVE} to {static_aot_runtime_dest}")
@@ -251,6 +272,15 @@ def make_local_release(
                 static_aot_runtime_link_config_dest,
             )
         )
+        shutil.copy2(STATIC_AOT_RUNTIME_SOURCE_ARCHIVE, static_aot_runtime_source_dest)
+        print(
+            "Copied {} to {}".format(
+                STATIC_AOT_RUNTIME_SOURCE_ARCHIVE,
+                static_aot_runtime_source_dest,
+            )
+        )
+        checksum_path = write_sha256sum(static_aot_runtime_source_dest)
+        print(f"Wrote {checksum_path}")
     except (FileNotFoundError, PermissionError) as e:
         print(f"Failed to copy standalone AOT runtime artifacts: {e}")
         sys.exit(1)

--- a/make_local_release_test.py
+++ b/make_local_release_test.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
+from pathlib import Path
+import tempfile
 import unittest
 
 import make_local_release
@@ -67,6 +70,35 @@ class MakeLocalReleaseTest(unittest.TestCase):
                     "/tmp/output",
                 ]
             )
+
+    def test_write_sha256sum_uses_release_asset_basename(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            archive = Path(tmp_dir) / "xls-aot-runtime-source.tar.gz"
+            archive.write_bytes(b"runtime-source")
+
+            checksum_path = Path(make_local_release.write_sha256sum(str(archive)))
+
+            self.assertEqual(
+                checksum_path.read_text(encoding="utf-8"),
+                "{}  xls-aot-runtime-source.tar.gz\n".format(
+                    hashlib.sha256(b"runtime-source").hexdigest()
+                ),
+            )
+
+    def test_release_workflow_uploads_runtime_source_asset(self):
+        workflow = (
+            Path(__file__).parent
+            / ".github"
+            / "workflows"
+            / "build-and-release-dylib.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("//xls/public:standalone_aot_runtime_source_archive", workflow)
+        self.assertIn("ubuntu2004-artifacts/xls-aot-runtime-source.tar.gz", workflow)
+        self.assertIn(
+            "ubuntu2004-artifacts/xls-aot-runtime-source.tar.gz.sha256",
+            workflow,
+        )
 
 
 if __name__ == "__main__":

--- a/xls/public/BUILD
+++ b/xls/public/BUILD
@@ -17,6 +17,8 @@
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//xls/build_rules:py_oss_defs.bzl", "pytype_strict_binary")
 load("//xls/build_rules:xls_static_library_bundle.bzl", "xls_static_library_bundle")
 load("//xls/public:xls_public_macros.oss.bzl", "libxls_dylib_binary", "py_test_c_api_symbols")
@@ -316,22 +318,24 @@ cc_library(
     ],
 )
 
+# Bazel-native source owner for the standalone runtime implementation. Released
+# source bundles package this target for mixed Bazel final links, while the
+# archive below flattens the same implementation for direct native consumers.
+cc_library(
+    name = "standalone_aot_runtime",
+    srcs = ["standalone_aot_runtime.cc"],
+    hdrs = ["standalone_aot_runtime.h"],
+    deps = ["//xls/jit:generated_code_callback_abi"],
+)
+
 # Public static archive linked into copied standalone AOT executables so they do
-# not need a runtime `libxls` DSO. This deliberately bundles the LLVM-free
-# runtime closure into one archive instead of asking downstream consumers to
+# not need a runtime `libxls` DSO. This deliberately bundles the standalone
+# source target into one archive instead of asking direct native consumers to
 # reconstruct the same link line independently.
 xls_static_library_bundle(
     name = "xls_aot_runtime",
-    srcs = ["standalone_aot_runtime.cc"],
     hdrs = ["standalone_aot_runtime.h"],
-    deps = [
-        "//xls/ir:events",
-        "//xls/ir:value",
-        "//xls/jit:aot_runtime",
-        "//xls/jit:generated_code_callbacks",
-        "//xls/jit:generated_code_callback_abi",
-        "//xls/jit:type_layout",
-    ],
+    deps = [":standalone_aot_runtime"],
 )
 
 # Locks down the direct-call/assertion contract and future trace rejection for
@@ -346,6 +350,57 @@ cc_test(
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
+)
+
+# Locks down the importable source target that downstream Bazel consumers load
+# from the released source tarball.
+cc_test(
+    name = "standalone_aot_runtime_surface_test",
+    srcs = ["standalone_aot_runtime_surface_test.cc"],
+    deps = [
+        ":standalone_aot_runtime",
+        "//xls/jit:generated_code_callback_abi",
+    ],
+)
+
+pkg_files(
+    name = "standalone_aot_runtime_source_repo_files",
+    srcs = [
+        "standalone_aot_runtime_source.BUILD.bazel",
+        "standalone_aot_runtime_source.MODULE.bazel",
+    ],
+    renames = {
+        "standalone_aot_runtime_source.BUILD.bazel": "BUILD.bazel",
+        "standalone_aot_runtime_source.MODULE.bazel": "MODULE.bazel",
+    },
+)
+
+pkg_files(
+    name = "standalone_aot_runtime_source_public_files",
+    srcs = [
+        "standalone_aot_runtime.cc",
+        "standalone_aot_runtime.h",
+    ],
+    prefix = "/xls/public",
+    strip_prefix = strip_prefix.from_pkg(),
+)
+
+pkg_files(
+    name = "standalone_aot_runtime_source_jit_files",
+    srcs = ["//xls/jit:generated_code_callback_abi.h"],
+    prefix = "/xls/jit",
+    strip_prefix = strip_prefix.from_pkg(),
+)
+
+pkg_tar(
+    name = "standalone_aot_runtime_source_archive",
+    srcs = [
+        ":standalone_aot_runtime_source_jit_files",
+        ":standalone_aot_runtime_source_public_files",
+        ":standalone_aot_runtime_source_repo_files",
+    ],
+    extension = "tar.gz",
+    package_file_name = "xls-aot-runtime-source.tar.gz",
 )
 
 cc_library(

--- a/xls/public/standalone_aot_runtime.cc
+++ b/xls/public/standalone_aot_runtime.cc
@@ -19,10 +19,11 @@
 #include <cstdlib>
 #include <new>
 #include <string>
+#include <vector>
 
-#include "xls/ir/events.h"
 #include "xls/jit/generated_code_callback_abi.h"
-#include "xls/jit/generated_code_callbacks.h"
+
+struct xls_standalone_aot_runtime;
 
 namespace {
 
@@ -95,20 +96,23 @@ void UnsupportedRecordActiveRegisterWrite(xls::InstanceContext* thiz,
   UnsupportedCallback();
 }
 
-// Callback table installed behind the ABI-visible prefix of the runtime
-// object. Unsupported slots stay present so generated-code offsets remain ABI
+void RecordAssertion(xls::InstanceContext* thiz, const char* msg,
+                     xls::InterpreterEvents* events);
+void* AllocateBuffer(xls::InstanceContext* thiz, int64_t byte_size,
+                     int64_t alignment);
+void DeallocateBuffer(xls::InstanceContext* thiz, void* ptr);
+
+// Callback table installed behind the ABI-visible prefix of the runtime object.
+// Unsupported slots stay present so generated-code offsets remain ABI
 // compatible, but they abort if a non-negotiated feature somehow reaches them.
 struct StandaloneAotCallbackTable final : xls::InstanceContextVTable {
   StandaloneAotCallbackTable()
       : xls::InstanceContextVTable(
             &UnsupportedPerformStringStep, &UnsupportedPerformFormatStep,
             &UnsupportedRecordTrace, &UnsupportedCreateTraceBuffer,
-            &xls::generated_code_callbacks::RecordAssertion,
-            &UnsupportedQueueReceiveWrapper,
+            &RecordAssertion, &UnsupportedQueueReceiveWrapper,
             &UnsupportedQueueSendWrapper, &UnsupportedRecordActiveNextValue,
-            &UnsupportedRecordNodeResult,
-            &xls::generated_code_callbacks::AllocateBuffer,
-            &xls::generated_code_callbacks::DeallocateBuffer,
+            &UnsupportedRecordNodeResult, &AllocateBuffer, &DeallocateBuffer,
             &UnsupportedRecordActiveRegisterWrite) {}
 };
 
@@ -116,15 +120,51 @@ struct StandaloneAotCallbackTable final : xls::InstanceContextVTable {
 constexpr uint32_t kSupportedFeatures =
     XLS_STANDALONE_AOT_RUNTIME_FEATURE_ASSERTIONS;
 
+int64_t RoundUpToAlignment(int64_t byte_size, int64_t alignment) {
+  int64_t remainder = byte_size % alignment;
+  if (remainder == 0) {
+    return byte_size;
+  } else {
+    return byte_size + alignment - remainder;
+  }
+}
+
 }  // namespace
 
 // Runtime object whose first bytes are the callback table seen by generated
-// code. Assertion storage reuses the same `InterpreterEvents` path as the full
-// JIT runtime so standalone execution does not grow a second event model.
+// code. The standalone source bundle owns its assertion storage instead of
+// depending on XLS event types that would pull a wider native closure into
+// mixed Bazel final links.
 struct xls_standalone_aot_runtime {
   StandaloneAotCallbackTable vtable;
-  xls::InterpreterEvents events;
+  std::vector<std::string> assert_messages;
 };
+
+namespace {
+
+xls_standalone_aot_runtime* RuntimeFromContext(xls::InstanceContext* thiz) {
+  return reinterpret_cast<xls_standalone_aot_runtime*>(thiz);
+}
+
+void RecordAssertion(xls::InstanceContext* thiz, const char* msg,
+                     xls::InterpreterEvents* events) {
+  RuntimeFromContext(thiz)->assert_messages.push_back(msg);
+}
+
+void* AllocateBuffer(xls::InstanceContext* thiz, int64_t byte_size,
+                     int64_t alignment) {
+  int64_t adjusted_size = RoundUpToAlignment(byte_size, alignment);
+  void* buffer = std::aligned_alloc(alignment, adjusted_size);
+  if (buffer == nullptr) {
+    std::abort();
+  } else {
+    return buffer;
+  }
+}
+
+void DeallocateBuffer(xls::InstanceContext* thiz, void* ptr) { std::free(ptr); }
+
+}  // namespace
 
 // Validates feature negotiation before allocating the standalone runtime
 // object, so unreachable callbacks remain a construction-time contract.
@@ -142,9 +182,10 @@ enum xls_standalone_aot_runtime_status xls_standalone_aot_runtime_create(
     if (runtime == nullptr) {
       *out = nullptr;
       return XLS_STANDALONE_AOT_RUNTIME_STATUS_ALLOCATION_FAILED;
+    } else {
+      *out = runtime;
+      return XLS_STANDALONE_AOT_RUNTIME_STATUS_OK;
     }
-    *out = runtime;
-    return XLS_STANDALONE_AOT_RUNTIME_STATUS_OK;
   }
 }
 
@@ -157,24 +198,23 @@ void xls_standalone_aot_runtime_free(
 // Clears event payloads while keeping one reusable runtime object alive.
 void xls_standalone_aot_runtime_clear_events(
     struct xls_standalone_aot_runtime* runtime) {
-  runtime->events.Clear();
+  runtime->assert_messages.clear();
 }
 
 // Exposes the number of assertion messages currently retained by the runtime.
 size_t xls_standalone_aot_runtime_get_assert_message_count(
     const struct xls_standalone_aot_runtime* runtime) {
-  return runtime->events.GetAssertMessageCount();
+  return runtime->assert_messages.size();
 }
 
 // Returns one retained assertion message, or null when the caller asks past the
 // retained range.
 const char* xls_standalone_aot_runtime_get_assert_message(
     const struct xls_standalone_aot_runtime* runtime, size_t index) {
-  const std::string* message = runtime->events.GetAssertMessage(index);
-  if (message == nullptr) {
+  if (index >= runtime->assert_messages.size()) {
     return nullptr;
   } else {
-    return message->c_str();
+    return runtime->assert_messages[index].c_str();
   }
 }
 
@@ -188,9 +228,9 @@ int64_t xls_standalone_aot_entrypoint_trampoline(
   StandaloneAotFunctionEntrypoint entrypoint =
       std::bit_cast<StandaloneAotFunctionEntrypoint>(function_ptr);
   int64_t continuation = entrypoint(
-      inputs, outputs, temp_buffer, &runtime->events,
+      inputs, outputs, temp_buffer, /*events=*/nullptr,
       reinterpret_cast<xls::InstanceContext*>(&runtime->vtable),
       /*jit_runtime=*/nullptr, continuation_point);
-  *assert_messages_count_out = runtime->events.GetAssertMessageCount();
+  *assert_messages_count_out = runtime->assert_messages.size();
   return continuation;
 }

--- a/xls/public/standalone_aot_runtime_source.BUILD.bazel
+++ b/xls/public/standalone_aot_runtime_source.BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "standalone_aot_runtime",
+    srcs = ["xls/public/standalone_aot_runtime.cc"],
+    hdrs = [
+        "xls/jit/generated_code_callback_abi.h",
+        "xls/public/standalone_aot_runtime.h",
+    ],
+    copts = ["-std=c++20"],
+    includes = ["."],
+)

--- a/xls/public/standalone_aot_runtime_source.MODULE.bazel
+++ b/xls/public/standalone_aot_runtime_source.MODULE.bazel
@@ -1,0 +1,3 @@
+module(name = "xls_standalone_aot_runtime_source")
+
+bazel_dep(name = "rules_cc", version = "0.2.11")

--- a/xls/public/standalone_aot_runtime_surface_test.cc
+++ b/xls/public/standalone_aot_runtime_surface_test.cc
@@ -1,0 +1,66 @@
+// Copyright 2026 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/public/standalone_aot_runtime.h"
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "xls/jit/generated_code_callback_abi.h"
+
+namespace {
+
+int64_t FakeAssertEntrypoint(const uint8_t* const* inputs,
+                             uint8_t* const* outputs, void* temp_buffer,
+                             xls::InterpreterEvents* events,
+                             xls::InstanceContext* instance_context,
+                             xls::JitRuntime* jit_runtime,
+                             int64_t continuation_point) {
+  auto* vtable = reinterpret_cast<xls::InstanceContextVTable*>(instance_context);
+  outputs[0][0] = inputs[0][0] + 1;
+  vtable->record_assertion(instance_context, "producer-surface", events);
+  return 0;
+}
+
+}  // namespace
+
+int main() {
+  xls_standalone_aot_runtime* runtime = nullptr;
+  assert(xls_standalone_aot_runtime_create(
+             XLS_STANDALONE_AOT_ABI_VERSION,
+             XLS_STANDALONE_AOT_RUNTIME_FEATURE_ASSERTIONS, &runtime) ==
+         XLS_STANDALONE_AOT_RUNTIME_STATUS_OK);
+  assert(runtime != nullptr);
+
+  uint8_t input = 41;
+  uint8_t output = 0;
+  const uint8_t* inputs[1] = {&input};
+  uint8_t* outputs[1] = {&output};
+  uint8_t temp_buffer[1] = {0};
+  size_t assert_messages_count = 0;
+
+  assert(xls_standalone_aot_entrypoint_trampoline(
+             reinterpret_cast<uintptr_t>(&FakeAssertEntrypoint), inputs,
+             outputs, temp_buffer, runtime, /*continuation_point=*/0,
+             &assert_messages_count) == 0);
+  assert(output == 42);
+  assert(assert_messages_count == 1);
+  assert(std::string{xls_standalone_aot_runtime_get_assert_message(runtime, 0)} ==
+         "producer-surface");
+
+  xls_standalone_aot_runtime_free(runtime);
+  return 0;
+}


### PR DESCRIPTION
This change gives Bazel consumers a small source-backed standalone AOT runtime surface from XLS, so they can compile the runtime into their own native link instead of importing the flattened standalone archive into a mixed Bazel link. The existing `libxls_aot_runtime.a` release path stays intact for direct native consumers.

# Problem Solved

The standalone runtime release currently has one native payload for downstream links: a flattened static archive. That works for direct native users, but it is not the right Bazel boundary when a downstream final link already owns native dependencies and needs Bazel to reason about the runtime as source. XLS should own that source boundary instead of asking downstream repositories to reconstruct a subset of the runtime closure.

Minimized example:

```text
Direct native consumer:
  link generated object + libxls_aot_runtime.a

Mixed Bazel consumer:
  cc_binary(deps = [runtime_source_target, other Bazel native deps])
```

This change keeps the first path and adds an XLS-published source asset for the second path.

# What Changed

- Factor `//xls/public:standalone_aot_runtime` into the Bazel source owner shared by the flattened archive path.
- Keep that source target narrow by handling assertion storage and buffer callbacks inside the standalone runtime implementation rather than depending on the wider XLS callback closure.
- Package an importable `xls-aot-runtime-source.tar.gz` repo surface with its `BUILD.bazel`, `MODULE.bazel`, runtime source/header, and generated-code callback ABI header.
- Add a producer surface test and teach local and GitHub release helpers to emit the source tarball plus checksum.

# Validation

- `bazel test //xls/public:standalone_aot_runtime_surface_test`
- `bazel build //xls/public:standalone_aot_runtime_source_archive`
- `python3 -m unittest make_local_release_test.py release_runtime_closure_test.py`