### PR TITLE
release: publish standalone AOT source archive on Ubuntu

### DIFF
--- a/.github/workflows/build-and-release-dylib.yml
+++ b/.github/workflows/build-and-release-dylib.yml
@@ -341,6 +341,7 @@ jobs:
           //xls/public:libxls.so \
           //xls/public:c_api \
           //xls/public:xls_aot_runtime \
+          //xls/public:standalone_aot_runtime_source_archive \
           //xls/dslx:interpreter_main \
           //xls/dslx/lsp:dslx_ls \
           //xls/tools:opt_main \


### PR DESCRIPTION
The Ubuntu release lane now builds `//xls/public:standalone_aot_runtime_source_archive` before copying `bazel-bin/xls/public/xls-aot-runtime-source.tar.gz`, so release packaging can include the source archive listed in its assets.

The v0.50.0 release run failed because Ubuntu copied that archive without building its Bazel producer target. Rocky 8 and `make_local_release.py` already build it; this aligns the Ubuntu lane with the existing packaging contract.

Minimized example: before this change, Ubuntu built `//xls/public:xls_aot_runtime` and then `cp bazel-bin/xls/public/xls-aot-runtime-source.tar.gz ...` failed because no target had generated the tarball. With this change, the preceding Bazel build includes the target that produces that exact path.

Validation:
- Confirmed the failure in https://github.com/xlsynth/xlsynth/actions/runs/26270257157: the Ubuntu copy step cannot stat `bazel-bin/xls/public/xls-aot-runtime-source.tar.gz`, and the release job is skipped.
- `git diff --check`
- Attempted `bazelisk build -c opt --cxxopt=-std=c++20 --host_cxxopt=-std=c++20 //xls/public:xls_aot_runtime`; local compilation could not proceed because this environment could not fetch Bazel Central Registry modules.